### PR TITLE
Команда /set_contract для добавления договоров студентов

### DIFF
--- a/src/main/java/com/nekromant/telegram/commands/SetContractCommand.java
+++ b/src/main/java/com/nekromant/telegram/commands/SetContractCommand.java
@@ -1,0 +1,73 @@
+package com.nekromant.telegram.commands;
+
+import com.nekromant.telegram.model.Contract;
+import com.nekromant.telegram.service.ContractService;
+import com.nekromant.telegram.utils.ValidationUtils;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+import org.telegram.telegrambots.meta.api.methods.send.SendMessage;
+import org.telegram.telegrambots.meta.api.objects.Chat;
+import org.telegram.telegrambots.meta.api.objects.User;
+import org.telegram.telegrambots.meta.bots.AbsSender;
+
+import javax.management.InstanceNotFoundException;
+import java.time.LocalDate;
+
+import static com.nekromant.telegram.contants.Command.SET_CONTRACT;
+import static com.nekromant.telegram.contants.MessageContants.NOT_OWNER_ERROR;
+import static com.nekromant.telegram.utils.FormatterUtils.defaultDateFormatter;
+
+@Component
+public class SetContractCommand extends MentoringReviewCommand {
+
+    @Value("${owner.userName}")
+    private String ownerUserName;
+
+    @Autowired
+    private ContractService contractService;
+
+    public SetContractCommand() {
+        super(SET_CONTRACT.getAlias(), SET_CONTRACT.getDescription());
+    }
+
+    @Override
+    public void execute(AbsSender absSender, User user, Chat chat, String[] arguments) {
+        SendMessage message = new SendMessage();
+        String chatId = chat.getId().toString();
+        String studentUserName;
+        String contractId;
+        LocalDate date;
+        message.setChatId(chatId);
+        if (!user.getUserName().equals(ownerUserName)) {
+            message.setText(NOT_OWNER_ERROR);
+            execute(absSender, message, user);
+            return;
+        }
+        try {
+            ValidationUtils.validateArguments(arguments);
+            studentUserName = arguments[0].replaceAll("@", "");
+            contractId = arguments[1];
+            date = LocalDate.parse(arguments[2], defaultDateFormatter());
+
+        }  catch (Exception e) {
+            message.setText("Пример: \n" +
+                    "/set_contract @kyomexd 1234567890 05.05.2023\n\n"
+                    + e.getMessage());
+            execute(absSender, message, user);
+            return;
+        }
+        try {
+            Contract contract = contractService.getContractByUsername(studentUserName);
+            contractService.updateContract(studentUserName, contractId, date);
+            message.setText("Было изменено для " + studentUserName +
+                    " с " + contract.getContractId() + " " + contract.getDate().format(defaultDateFormatter()) +
+                    " на " + contractId + " " + date.format(defaultDateFormatter()));
+
+        } catch (InstanceNotFoundException e) {
+            contractService.saveContract(new Contract(studentUserName, contractId, date));
+            message.setText("Заданы новые данные для " + studentUserName + " " + contractId + " " + date.format(defaultDateFormatter()));
+        }
+        execute(absSender, message, user);
+    }
+}

--- a/src/main/java/com/nekromant/telegram/contants/Command.java
+++ b/src/main/java/com/nekromant/telegram/contants/Command.java
@@ -20,7 +20,8 @@ public enum Command {
     SET_SALARY("set_salary", "Установить новое значение зп"),
     NOTIFY_REVIEW_ON("notify_review_on", "Уведолять о всех ревью"),
     NOTIFY_REVIEW_OFF("notify_review_off", "Не уведолять о всех ревью"),
-    SET_SCHEDULE_PERIOD("set_schedule_period", "Установить период времени, за который выводить список ревью");
+    SET_SCHEDULE_PERIOD("set_schedule_period", "Установить период времени, за который выводить список ревью"),
+    SET_CONTRACT("set_contract", "Задать номер договора студента");
     private String alias;
     private String description;
 

--- a/src/main/java/com/nekromant/telegram/model/Contract.java
+++ b/src/main/java/com/nekromant/telegram/model/Contract.java
@@ -1,0 +1,24 @@
+package com.nekromant.telegram.model;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import javax.persistence.*;
+import java.time.LocalDate;
+
+@Data
+@Entity
+@AllArgsConstructor
+@NoArgsConstructor
+public class Contract {
+
+    @Id
+    private String username;
+
+    @Column
+    private String contractId;
+
+    @Column
+    private LocalDate date;
+}

--- a/src/main/java/com/nekromant/telegram/repository/ContractRepository.java
+++ b/src/main/java/com/nekromant/telegram/repository/ContractRepository.java
@@ -1,0 +1,7 @@
+package com.nekromant.telegram.repository;
+
+import com.nekromant.telegram.model.Contract;
+import org.springframework.data.repository.CrudRepository;
+
+public interface ContractRepository extends CrudRepository<Contract, String> {
+}

--- a/src/main/java/com/nekromant/telegram/service/ContractService.java
+++ b/src/main/java/com/nekromant/telegram/service/ContractService.java
@@ -1,0 +1,33 @@
+package com.nekromant.telegram.service;
+
+import com.nekromant.telegram.model.Contract;
+import com.nekromant.telegram.repository.ContractRepository;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+
+import javax.management.InstanceNotFoundException;
+import java.time.LocalDate;
+
+@Service
+public class ContractService {
+
+    @Autowired
+    private ContractRepository contractRepository;
+
+    public Contract getContractByUsername(String username) throws InstanceNotFoundException {
+        return contractRepository.findById(username).orElseThrow(() -> new InstanceNotFoundException("No contract bound to this username"));
+    }
+
+    public void updateContract(String username, String contractId, LocalDate date) throws InstanceNotFoundException {
+        Contract contract = getContractByUsername(username);
+        contract.setContractId(contractId);
+        contract.setDate(date);
+        saveContract(contract);
+    }
+
+    public void saveContract(Contract contract) {
+        contractRepository.save(contract);
+    }
+
+
+}


### PR DESCRIPTION
Ввод формата  "/set_contract @имяпользователя номер_договора_строкой_без_пробелов 14.01.2023" сохраняет имя пользователя, номер договора и дату в отдельной таблице без связей

