### PR TITLE
Пофиксил напоминание об отчётах для менторов. Отфильтровал ревью на одобрении с занятыми таймслотами

### DIFF
--- a/src/main/java/com/nekromant/telegram/MentoringReviewBot.java
+++ b/src/main/java/com/nekromant/telegram/MentoringReviewBot.java
@@ -78,6 +78,10 @@ public class MentoringReviewBot extends TelegramLongPollingCommandBot {
                 Long reviewId = Long.parseLong(callBackData.split(" ")[1]);
                 int timeSlot = Integer.parseInt(callBackData.split(" ")[2]);
                 ReviewRequest review = reviewRequestRepository.findById(reviewId).orElseThrow(InvalidParameterException::new);
+                if (reviewRequestRepository.existsByBookedDateTime(LocalDateTime.of(review.getDate(), LocalTime.of(timeSlot, 0)))) {
+                    log.error("Time slot already booked: {}", timeSlot);
+                    throw new InvalidParameterException("Time slot already booked: " + timeSlot);
+                }
                 review.setBookedDateTime(LocalDateTime.of(review.getDate(), LocalTime.of(timeSlot, 0)));
                 review.setMentorUserName(update.getCallbackQuery().getFrom().getUserName());
                 reviewRequestRepository.save(review);

--- a/src/main/java/com/nekromant/telegram/commands/mentors/MyOffCommand.java
+++ b/src/main/java/com/nekromant/telegram/commands/mentors/MyOffCommand.java
@@ -33,7 +33,7 @@ public class MyOffCommand extends MentoringReviewCommand {
         message.disableNotification();
 
         try {
-            Mentor mentor = mentorRepository.findMentorByUserName(user.getUserName());
+            Mentor mentor = mentorRepository.findMentorByUserNameIgnoreCase(user.getUserName());
             if (mentor == null) {
                 message.setText("Ты не ментор");
                 execute(absSender, message, user);

--- a/src/main/java/com/nekromant/telegram/commands/mentors/MyOnCommand.java
+++ b/src/main/java/com/nekromant/telegram/commands/mentors/MyOnCommand.java
@@ -32,7 +32,7 @@ public class MyOnCommand extends MentoringReviewCommand {
         message.setChatId(chatId);
         message.disableNotification();
         try {
-            Mentor mentor = mentorRepository.findMentorByUserName(user.getUserName());
+            Mentor mentor = mentorRepository.findMentorByUserNameIgnoreCase(user.getUserName());
             if (mentor == null) {
                 message.setText("Ты не ментор");
                 execute(absSender, message, user);

--- a/src/main/java/com/nekromant/telegram/commands/report/ReportDeleteCommand.java
+++ b/src/main/java/com/nekromant/telegram/commands/report/ReportDeleteCommand.java
@@ -44,7 +44,7 @@ public class ReportDeleteCommand extends MentoringReviewCommand {
                 execute(absSender, message, user);
                 return;
             }
-            reportRepository.deleteByStudentUserName(strings[0].replaceAll("@", ""));
+            reportRepository.deleteByStudentUserNameIgnoreCase(strings[0].replaceAll("@", ""));
             message.setText(REPORTS_DELETED);
             execute(absSender, message, user);
         } catch (Exception e) {

--- a/src/main/java/com/nekromant/telegram/commands/review/ReviewCommand.java
+++ b/src/main/java/com/nekromant/telegram/commands/review/ReviewCommand.java
@@ -182,7 +182,6 @@ public class ReviewCommand extends MentoringReviewCommand {
         List<UserInfo> allMentors = userInfoRepository.findAllByUserType(UserType.MENTOR);
         for (UserInfo mentor : allMentors) {
             isNotTakenByAllMentors = !reviewRequestRepository.existsByBookedDateTimeAndMentorUserName(LocalDateTime.of(reviewRequestDate, LocalTime.of(timeSlot, 0)), mentor.getUserName());
-            log.info("Время {} {} {}", timeSlot, mentor.getUserName(), isNotTakenByAllMentors ? "свободно" : "занято");
         }
         return isNotTakenByAllMentors;
     }

--- a/src/main/java/com/nekromant/telegram/commands/review/ReviewCommand.java
+++ b/src/main/java/com/nekromant/telegram/commands/review/ReviewCommand.java
@@ -21,6 +21,8 @@ import org.telegram.telegrambots.meta.bots.AbsSender;
 
 import java.security.InvalidParameterException;
 import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.LocalTime;
 import java.time.ZoneId;
 import java.util.*;
 import java.util.stream.Collectors;
@@ -133,8 +135,11 @@ public class ReviewCommand extends MentoringReviewCommand {
         InlineKeyboardMarkup inlineKeyboardMarkup = new InlineKeyboardMarkup();
         List<List<InlineKeyboardButton>> rowList = new ArrayList<>();
 
-
-        reviewRequest.getTimeSlots().forEach(x -> {
+        LocalDate reviewRequestDate = reviewRequest.getDate();
+        reviewRequest.getTimeSlots().
+                stream().
+                filter(timeSlot -> !reviewRequestRepository.existsByBookedDateTime(LocalDateTime.of(reviewRequestDate, LocalTime.of(timeSlot, 0)))).
+                forEach(x -> {
             List<InlineKeyboardButton> keyboardButtonRow = new ArrayList<>();
             InlineKeyboardButton inlineKeyboardButton = new InlineKeyboardButton();
             inlineKeyboardButton.setText(x + ":00");

--- a/src/main/java/com/nekromant/telegram/commands/review/ReviewTodayCommand.java
+++ b/src/main/java/com/nekromant/telegram/commands/review/ReviewTodayCommand.java
@@ -79,9 +79,8 @@ public class ReviewTodayCommand extends MentoringReviewCommand {
                             .collect(Collectors.joining("\n"));
             message.setText(messageWithReviewsToday);
             message.disableWebPagePreview();
+            execute(absSender, message, user);
         }
-
-        execute(absSender, message, user);
     }
 
     @SneakyThrows

--- a/src/main/java/com/nekromant/telegram/commands/review/ReviewTodayCommand.java
+++ b/src/main/java/com/nekromant/telegram/commands/review/ReviewTodayCommand.java
@@ -26,6 +26,7 @@ import java.util.*;
 import java.util.stream.Collectors;
 
 import static com.nekromant.telegram.contants.Command.REVIEW_TODAY;
+import static com.nekromant.telegram.contants.MessageContants.NO_REVIEW_TODAY;
 import static com.nekromant.telegram.utils.FormatterUtils.defaultDateTimeFormatter;
 import static java.time.temporal.ChronoUnit.DAYS;
 
@@ -66,18 +67,21 @@ public class ReviewTodayCommand extends MentoringReviewCommand {
                             LocalDate.now(ZoneId.of("Europe/Moscow")).atStartOfDay(),
                             LocalDate.now(ZoneId.of("Europe/Moscow")).plus(1, DAYS).atStartOfDay()
                     );
-
-            String messageWithReviewsToday = "Расписание ревью на сегодня\n\n" +
-                    reviewsToday.stream()
-                            .sorted(Comparator.comparing(ReviewRequest::getBookedDateTime))
-                            .map(review ->
-                                    "@" + review.getStudentUserName() + "\n" +
-                                            review.getBookedDateTime().format(defaultDateTimeFormatter()) + "\n" +
-                                            review.getTitle() + "\n" +
-                                            "@" + review.getMentorUserName() + "\n" +
-                                            mentorRepository.findMentorByUserName(review.getMentorUserName()).getRoomUrl() + "\n")
-                            .collect(Collectors.joining("\n"));
-            message.setText(messageWithReviewsToday);
+            if (reviewsToday.isEmpty()) {
+                message.setText(NO_REVIEW_TODAY);
+            } else {
+                String messageWithReviewsToday = "Расписание ревью на сегодня\n\n" +
+                        reviewsToday.stream()
+                                .sorted(Comparator.comparing(ReviewRequest::getBookedDateTime))
+                                .map(review ->
+                                        "@" + review.getStudentUserName() + "\n" +
+                                                review.getBookedDateTime().format(defaultDateTimeFormatter()) + "\n" +
+                                                review.getTitle() + "\n" +
+                                                "@" + review.getMentorUserName() + "\n" +
+                                                mentorRepository.findMentorByUserNameIgnoreCase(review.getMentorUserName()).getRoomUrl() + "\n")
+                                .collect(Collectors.joining("\n"));
+                message.setText(messageWithReviewsToday);
+            }
             message.disableWebPagePreview();
             execute(absSender, message, user);
         }

--- a/src/main/java/com/nekromant/telegram/contants/MessageContants.java
+++ b/src/main/java/com/nekromant/telegram/contants/MessageContants.java
@@ -23,6 +23,7 @@ public class MessageContants {
     public static final String SOMEBODY_DENIED_REVIEW = "@%s отменил ревью с @%s";
     public static final String REVIEW_REQUEST_SENT = "Запрос отправлен менторам, ответ скоро придет";
     public static final String REVIEW_INCOMING = "Скоро ревью у @%s с @%s\n%s\n%s\n%s";
+    public static final String NO_REVIEW_TODAY = "На сегодня ревью не назначено";
     public static final String USER_STAT_MESSAGE =
             "@%s\nВсего дней - %s\nУчился дней - %s\nУчился часов - %s\nВ среднем в неделю - %s часов";
 

--- a/src/main/java/com/nekromant/telegram/repository/MentorRepository.java
+++ b/src/main/java/com/nekromant/telegram/repository/MentorRepository.java
@@ -10,5 +10,5 @@ public interface MentorRepository extends CrudRepository<Mentor, String> {
 
     List<Mentor> findAllByIsActiveIsTrue();
 
-    Mentor findMentorByUserName(String userName);
+    Mentor findMentorByUserNameIgnoreCase(String userName);
 }

--- a/src/main/java/com/nekromant/telegram/repository/ReportRepository.java
+++ b/src/main/java/com/nekromant/telegram/repository/ReportRepository.java
@@ -24,6 +24,6 @@ public interface ReportRepository extends CrudRepository<Report, Long> {
     List<Report> findAllByDateIs(LocalDate date);
 
     @Transactional
-    void deleteByStudentUserName(String studentUserName);
+    void deleteByStudentUserNameIgnoreCase(String studentUserName);
 
 }

--- a/src/main/java/com/nekromant/telegram/repository/ReviewRequestRepository.java
+++ b/src/main/java/com/nekromant/telegram/repository/ReviewRequestRepository.java
@@ -14,6 +14,5 @@ public interface ReviewRequestRepository extends CrudRepository<ReviewRequest, L
     List<ReviewRequest> findAllByBookedDateTimeBetween(LocalDateTime from, LocalDateTime to);
 
     List<ReviewRequest> findAll();
-
-    boolean existsByBookedDateTime(LocalDateTime dateTime);
+    boolean existsByBookedDateTimeAndMentorUserName(LocalDateTime dateTime, String mentorUserName);
 }

--- a/src/main/java/com/nekromant/telegram/repository/ReviewRequestRepository.java
+++ b/src/main/java/com/nekromant/telegram/repository/ReviewRequestRepository.java
@@ -14,4 +14,6 @@ public interface ReviewRequestRepository extends CrudRepository<ReviewRequest, L
     List<ReviewRequest> findAllByBookedDateTimeBetween(LocalDateTime from, LocalDateTime to);
 
     List<ReviewRequest> findAll();
+
+    boolean existsByBookedDateTime(LocalDateTime dateTime);
 }

--- a/src/main/java/com/nekromant/telegram/repository/UserInfoRepository.java
+++ b/src/main/java/com/nekromant/telegram/repository/UserInfoRepository.java
@@ -8,7 +8,7 @@ import java.util.*;
 public interface UserInfoRepository extends CrudRepository<UserInfo, String> {
     List<UserInfo> findAll();
 
-    UserInfo findUserInfoByUserName(String userName);
+    UserInfo findUserInfoByUserNameIgnoreCase(String userName);
 
     List<UserInfo> findAllByNotifyAboutReportsIsTrue();
 }

--- a/src/main/java/com/nekromant/telegram/repository/UserInfoRepository.java
+++ b/src/main/java/com/nekromant/telegram/repository/UserInfoRepository.java
@@ -1,5 +1,6 @@
 package com.nekromant.telegram.repository;
 
+import com.nekromant.telegram.contants.UserType;
 import com.nekromant.telegram.model.UserInfo;
 import org.springframework.data.repository.CrudRepository;
 
@@ -11,4 +12,5 @@ public interface UserInfoRepository extends CrudRepository<UserInfo, String> {
     UserInfo findUserInfoByUserNameIgnoreCase(String userName);
 
     List<UserInfo> findAllByNotifyAboutReportsIsTrue();
+    List<UserInfo> findAllByUserType(UserType userType);
 }

--- a/src/main/java/com/nekromant/telegram/service/SchedulePeriodService.java
+++ b/src/main/java/com/nekromant/telegram/service/SchedulePeriodService.java
@@ -71,7 +71,7 @@ public class SchedulePeriodService {
                         x.getTitle().replace("Тема:", ""),
                         x.getBookedDateTime().toString().replace("T", " "),
                         false,
-                        mentorRepository.findMentorByUserName(x.getMentorUserName()).getRoomUrl(),
+                        mentorRepository.findMentorByUserNameIgnoreCase(x.getMentorUserName()).getRoomUrl(),
                         true
                 ))
                 .sorted(Comparator.comparing(BookedReviewDTO::getBookedDateTime));

--- a/src/main/java/com/nekromant/telegram/service/UserInfoService.java
+++ b/src/main/java/com/nekromant/telegram/service/UserInfoService.java
@@ -45,7 +45,7 @@ public class UserInfoService {
     public void demoteMentorToUser(String userName) throws Exception {
         UserInfo userInfo = userInfoRepository.findUserInfoByUserNameIgnoreCase(userName);
         if (userInfo.getUserType() == UserType.MENTOR) {
-            Mentor deleteMentor = mentorRepository.findMentorByUserName(userName);
+            Mentor deleteMentor = mentorRepository.findMentorByUserNameIgnoreCase(userName);
             mentorRepository.delete(deleteMentor);
             userInfo.setUserType(UserType.DEV);
             userInfoRepository.save(userInfo);

--- a/src/main/java/com/nekromant/telegram/service/UserInfoService.java
+++ b/src/main/java/com/nekromant/telegram/service/UserInfoService.java
@@ -11,7 +11,6 @@ import org.telegram.telegrambots.meta.api.objects.Chat;
 import org.telegram.telegrambots.meta.api.objects.User;
 
 import java.util.List;
-import java.util.Optional;
 import java.util.stream.Collectors;
 
 @Service
@@ -25,7 +24,7 @@ public class UserInfoService {
 
     public void initializeUserInfo(Chat chat, User user) {
         if (chat.getType().equalsIgnoreCase("private")
-                && userInfoRepository.findUserInfoByUserName(user.getUserName()) == null) {
+                && userInfoRepository.findUserInfoByUserNameIgnoreCase(user.getUserName()) == null) {
             UserInfo userInfo = UserInfo.builder()
                     .userName(user.getUserName())
                     .chatId(chat.getId())
@@ -36,7 +35,7 @@ public class UserInfoService {
     }
 
     public void promoteUserToMentor(String userName) {
-        UserInfo userInfo = userInfoRepository.findUserInfoByUserName(userName);
+        UserInfo userInfo = userInfoRepository.findUserInfoByUserNameIgnoreCase(userName);
         if (userInfo.getUserType() != UserType.MENTOR) {
             userInfo.setUserType(UserType.MENTOR);
             userInfoRepository.save(userInfo);
@@ -44,7 +43,7 @@ public class UserInfoService {
     }
 
     public void demoteMentorToUser(String userName) throws Exception {
-        UserInfo userInfo = userInfoRepository.findUserInfoByUserName(userName);
+        UserInfo userInfo = userInfoRepository.findUserInfoByUserNameIgnoreCase(userName);
         if (userInfo.getUserType() == UserType.MENTOR) {
             Mentor deleteMentor = mentorRepository.findMentorByUserName(userName);
             mentorRepository.delete(deleteMentor);
@@ -62,7 +61,7 @@ public class UserInfoService {
     }
 
     public UserInfo getUserInfo(String userName) {
-        return userInfoRepository.findUserInfoByUserName(userName);
+        return userInfoRepository.findUserInfoByUserNameIgnoreCase(userName);
     }
 
     public void save(UserInfo userInfo) {

--- a/src/main/java/com/nekromant/telegram/sheduler/ReviewScheduler.java
+++ b/src/main/java/com/nekromant/telegram/sheduler/ReviewScheduler.java
@@ -55,14 +55,12 @@ public class ReviewScheduler {
                     reviewRequest.getStudentUserName(), reviewRequest.getMentorUserName(),
                     reviewRequest.getBookedDateTime().format(defaultDateTimeFormatter()),
                     reviewRequest.getTitle(),
-                    mentorRepository.findMentorByUserName(reviewRequest.getMentorUserName()).getRoomUrl());
-
+                    mentorRepository.findMentorByUserNameIgnoreCase(reviewRequest.getMentorUserName()).getRoomUrl());
             userInfoService.getAllUsersReportNotificationsEnabled()
                     .stream()
-                    .filter(x -> !x.getUserName().equals(reviewRequest.getStudentUserName()))
-                    .filter(x -> !x.getUserName().equals(reviewRequest.getMentorUserName()))
+                    .filter(x -> !x.getUserName().equalsIgnoreCase(reviewRequest.getStudentUserName()))
+                    .filter(x -> !x.getUserName().equalsIgnoreCase(reviewRequest.getMentorUserName()))
                     .forEach(x -> mentoringReviewBot.sendMessage(x.getChatId().toString(), reviewIncomingMessage));
-
             mentoringReviewBot.sendMessage(reviewRequest.getStudentChatId(), reviewIncomingMessage);
             mentoringReviewBot.sendMessage(userInfoService.getUserInfo(reviewRequest.getMentorUserName()).getChatId().toString(),
                     reviewIncomingMessage);


### PR DESCRIPTION
Add exception when callback tries to schedule review on existing time slot.
Add filter for approving message if time slot is taken. 
Fix exception during approving message callback.
Add checking for report reminders if user mentor or bot owner. 
UserInfoService is no longer depends on passed username case