### PR TITLE
CV without file extension - Fixed

### DIFF
--- a/src/main/java/com/nekromant/telegram/service/ResumeAnalysisRequestService.java
+++ b/src/main/java/com/nekromant/telegram/service/ResumeAnalysisRequestService.java
@@ -64,7 +64,7 @@ public class ResumeAnalysisRequestService extends ClientPaymentRequestServiceCom
 
         String receiverId = userInfoService.getUserInfo(ownerUserName).getChatId().toString();
         byte[] CV_bytes = resumeAnalysisRequestRepository.findByLifePayTransactionNumber(paymentDetails.getNumber()).getCVPdf();
-        FormData formData = new FormData(MediaType.MULTIPART_FORM_DATA, "document", CV_bytes);
+        FormData formData = new FormData(MediaType.MULTIPART_FORM_DATA, "document.pdf", CV_bytes);
         telegramFeign.sendDocument(formData, receiverId);
     }
 


### PR DESCRIPTION
Ранее:
- при оплате услуги апгрейда резюме в чат ментору приходил файл document без расширения (приходилось проставлять вручную)

Сейчас:
- при оплате услуги апгрейда резюме в чат ментору прилетает файл document.pdf, готовый к просмотру.