### PR TITLE
Отрефакторил обработку отредактированных сообщений-отчётов.

### DIFF
--- a/src/main/java/com/nekromant/telegram/MentoringReviewBot.java
+++ b/src/main/java/com/nekromant/telegram/MentoringReviewBot.java
@@ -244,7 +244,7 @@ public class MentoringReviewBot extends TelegramLongPollingCommandBot {
             Report temporaryReport = getTemporaryReport(update);
             reportRepository.save(temporaryReport);
 
-            SendMessage sendDatePicker = reportDateTimePicker.sendDatePicker(
+            SendMessage sendDatePicker = reportDateTimePicker.getDatePickerSendMessage(
                     update.getEditedMessage().getChatId().toString(),
                     temporaryReport,
                     update.getEditedMessage().getMessageId());
@@ -266,7 +266,7 @@ public class MentoringReviewBot extends TelegramLongPollingCommandBot {
             Report temporaryReport = getTemporaryReport(update);
             reportRepository.save(temporaryReport);
 
-            SendMessage sendDatePicker = reportDateTimePicker.sendDatePicker(
+            SendMessage sendDatePicker = reportDateTimePicker.getDatePickerSendMessage(
                     update.getEditedMessage().getChatId().toString(),
                     temporaryReport,
                     update.getEditedMessage().getMessageId());

--- a/src/main/java/com/nekromant/telegram/MentoringReviewBot.java
+++ b/src/main/java/com/nekromant/telegram/MentoringReviewBot.java
@@ -17,6 +17,7 @@ import com.nekromant.telegram.repository.ChatMessageRepository;
 import com.nekromant.telegram.repository.ReportRepository;
 import com.nekromant.telegram.repository.ReviewRequestRepository;
 import com.nekromant.telegram.repository.UserInfoRepository;
+import com.nekromant.telegram.service.ReportService;
 import com.nekromant.telegram.service.SpecialChatService;
 import com.nekromant.telegram.utils.SendMessageFactory;
 import lombok.SneakyThrows;
@@ -50,7 +51,6 @@ import java.util.stream.Collectors;
 import static com.nekromant.telegram.contants.Command.REPORT;
 import static com.nekromant.telegram.contants.MessageContants.REPORT_HELP_MESSAGE;
 import static com.nekromant.telegram.contants.MessageContants.UNKNOWN_COMMAND;
-import static com.nekromant.telegram.model.Report.getTemporaryReport;
 import static com.nekromant.telegram.utils.FormatterUtils.defaultDateFormatter;
 
 
@@ -78,6 +78,8 @@ public class MentoringReviewBot extends TelegramLongPollingCommandBot {
     private ReportRepository reportRepository;
     @Autowired
     private ReportDateTimePicker reportDateTimePicker;
+    @Autowired
+    private ReportService reportService;
 
     private final Map<CallBack, CallbackStrategy> callbackStrategyMap;
 
@@ -181,7 +183,7 @@ public class MentoringReviewBot extends TelegramLongPollingCommandBot {
         Integer userChatBotMessageId = reportChatMessage.getUserChatBotMessageId();
         Integer reportChatBotMessageId = reportChatMessage.getReportChatBotMessageId();
 
-        Report.updateReportFromEditedMessage(editedText, report);
+        reportService.updateReportFromEditedMessage(editedText, report);
         reportRepository.save(report);
 
 
@@ -241,7 +243,7 @@ public class MentoringReviewBot extends TelegramLongPollingCommandBot {
 
     private void handleNewReportForExistingMessage(Update update) throws TelegramApiException {
         try {
-            Report temporaryReport = getTemporaryReport(update);
+            Report temporaryReport = reportService.getTemporaryReport(update);
             reportRepository.save(temporaryReport);
 
             SendMessage sendDatePicker = reportDateTimePicker.getDatePickerSendMessage(
@@ -263,7 +265,7 @@ public class MentoringReviewBot extends TelegramLongPollingCommandBot {
 
     private void handleNewMessage(Update update) throws TelegramApiException {
         try {
-            Report temporaryReport = getTemporaryReport(update);
+            Report temporaryReport = reportService.getTemporaryReport(update);
             reportRepository.save(temporaryReport);
 
             SendMessage sendDatePicker = reportDateTimePicker.getDatePickerSendMessage(

--- a/src/main/java/com/nekromant/telegram/MentoringReviewBot.java
+++ b/src/main/java/com/nekromant/telegram/MentoringReviewBot.java
@@ -137,24 +137,32 @@ public class MentoringReviewBot extends TelegramLongPollingCommandBot {
 
     public void processEditedMessageUpdate(Update update) {
         if (isReportEdited(update)) {
-            log.info("Сообщение с отчётом отредактировано пользователем: {} (user id: {})", update.getMessage().getFrom().getUserName(), update.getMessage().getFrom().getId());
-            String editedText = update.getEditedMessage().getText();
-            Integer reportMessageId = update.getEditedMessage().getMessageId();
-            ChatMessage reportChatMessage = chatMessageRepository.findByUserMessageId(reportMessageId);
-
-            try {
-                if (reportChatMessage != null) {
-                    handleExistingMessage(update, reportChatMessage, editedText);
-                } else {
-                    handleNewMessage(update);
-                }
-            } catch (TelegramApiException e) {
-                log.error("Не удалось обработать сообщение отредактированное пользователем: {} (user id: {}). Возникла ошибка при отправке сообщения пользователю {}", update.getMessage().getFrom().getUserName(), update.getMessage().getFrom().getId(), e.getMessage(), e);
-            }
+            handleEditedReport(update);
         } else {
-            log.info("Неизвестный тип сообщения отредактирован пользователем: {} (user id: {}).", update.getMessage().getFrom().getUserName(), update.getMessage().getFrom().getId());
-            update.setMessage(update.getEditedMessage());
-            super.onUpdateReceived(update);
+            handleUnrecognizedEditedMessageType(update);
+        }
+    }
+
+    private void handleUnrecognizedEditedMessageType(Update update) {
+        log.info("Неизвестный тип сообщения отредактирован пользователем: {} (user id: {}).", update.getMessage().getFrom().getUserName(), update.getMessage().getFrom().getId());
+        update.setMessage(update.getEditedMessage());
+        super.onUpdateReceived(update);
+    }
+
+    private void handleEditedReport(Update update) {
+        log.info("Сообщение с отчётом отредактировано пользователем: {} (user id: {})", update.getMessage().getFrom().getUserName(), update.getMessage().getFrom().getId());
+        String editedText = update.getEditedMessage().getText();
+        Integer reportMessageId = update.getEditedMessage().getMessageId();
+        ChatMessage reportChatMessage = chatMessageRepository.findByUserMessageId(reportMessageId);
+
+        try {
+            if (reportChatMessage != null) {
+                handleExistingMessage(update, reportChatMessage, editedText);
+            } else {
+                handleNewMessage(update);
+            }
+        } catch (TelegramApiException e) {
+            log.error("Не удалось обработать сообщение отредактированное пользователем: {} (user id: {}). Возникла ошибка при отправке сообщения пользователю {}", update.getMessage().getFrom().getUserName(), update.getMessage().getFrom().getId(), e.getMessage(), e);
         }
     }
 

--- a/src/main/java/com/nekromant/telegram/callback_strategy/SetReportDateTimeCallbackStrategy.java
+++ b/src/main/java/com/nekromant/telegram/callback_strategy/SetReportDateTimeCallbackStrategy.java
@@ -68,58 +68,27 @@ public class SetReportDateTimeCallbackStrategy implements CallbackStrategy {
         ChatMessage currentMessage = chatMessageRepository.findByUserMessageId(messageId);
 
         if (currentMessage != null) {
-            log.debug("Редактирование. Сообщение существует в БД");
+            log.info("Редактирование. Сообщение существует в БД");
             handleExistingMessage(messageForUser, messageForReportsChat, updatedReport, currentMessage);
         } else {
-            log.debug("Новое сообщение. Сообщения не существует в БД");
+            log.info("Новое сообщение. Сообщения не существует в БД");
             handleNewMessage(messageForUser, messageForReportsChat, update, updatedReport, messageId);
         }
     }
 
     private void handleExistingMessage(SendMessage messageForUser, SendMessage messageForReportsChat, Report updatedReport, ChatMessage currentMessage) {
-        if (currentMessage.getReport() != null) {
-            log.debug("К текущему сообщению привязан отчёт");
-            handleExistingReport(messageForUser, messageForReportsChat, updatedReport, currentMessage);
-        } else {
-            log.debug("К текущему сообщению не привязан отчёт");
+        if (currentMessage.getReport() == null) {
+            log.info("К текущему сообщению не привязан отчёт");
             handleNewReportForExistingMessage(messageForUser, messageForReportsChat, updatedReport, currentMessage);
-        }
-    }
-
-    private void handleExistingReport(SendMessage messageForUser, SendMessage messageForReportsChat, Report updatedReport, ChatMessage currentMessage) {
-        Report currentMessageReport = currentMessage.getReport();
-
-        if (reportRepository.existsReportByDateAndStudentUserName(updatedReport.getDate(), updatedReport.getStudentUserName())) {
-            log.debug("Отчёт с новой датой существует");
-            if (isExistingReportEqualsReportFromCurrentMessage(currentMessage, updatedReport)) {
-                log.debug("Это отчёт, привязанный к текущему сообщению (обновить текущий отчёт)");
-                updateReportFromAnotherReport(updatedReport, currentMessageReport);
-
-                deleteNewTemporaryReport(updatedReport);
-
-                setMessageTextReportIsUpdated(messageForUser, updatedReport);
-                setMessageTextReportIsUpdated(messageForReportsChat, updatedReport);
-            } else {
-                log.debug("Это НЕ отчёт, привязанный к текущему сообщению (Написать юзеру, чтобы редактировал соответствующее сообщение)");
-
-                deleteNewTemporaryReport(updatedReport);
-
-                messageForUser.setText("Отчёт-сообщение с такой датой (" + defaultDateFormatter().format(updatedReport.getDate()) + ") уже есть. Отредактируйте его или выберите другую дату.");
-            }
         } else {
-            log.debug("Отчёта с новой датой не существует (обновить отчёт привязанный к текущему сообщению)");
-            updateReportFromAnotherReport(updatedReport, currentMessageReport);
-
-            deleteNewTemporaryReport(updatedReport);
-
-            setMessageTextReportIsUpdated(messageForUser, updatedReport);
-            setMessageTextReportIsUpdated(messageForReportsChat, updatedReport);
+            log.error("К текущему сообщению привязан отчёт. Ошибка в логике исполнения программы, обработка должна быть произведена в методе MentoringReviewBot.processEditedMessageUpdate().");
+            messageForUser.setText("Ошибка в логике исполнения программы. Обратитесь к разработчику.");
         }
     }
 
     private void handleNewReportForExistingMessage(SendMessage messageForUser, SendMessage messageForReportsChat, Report updatedReport, ChatMessage currentMessage) {
         if (reportRepository.existsReportByDateAndStudentUserName(updatedReport.getDate(), updatedReport.getStudentUserName())) {
-            log.debug("Отчёт с новой датой существует (обновить его и привязать к текущему сообщению)");
+            log.info("Отчёт с новой датой существует (обновить его и привязать к текущему сообщению)");
             List<Report> existingReportsOnReceivedDate = reportRepository.findByDateAndStudentUserName(updatedReport.getDate(), updatedReport.getStudentUserName());
             Report reportLikeReceived = existingReportsOnReceivedDate.get(0);
             deleteDuplicateReports(existingReportsOnReceivedDate);
@@ -132,13 +101,11 @@ public class SetReportDateTimeCallbackStrategy implements CallbackStrategy {
             setMessageTextReportIsUpdated(messageForUser, updatedReport);
             setMessageTextReportIsUpdated(messageForReportsChat, updatedReport);
         } else {
-            log.debug("Отчёта с новой датой не существует (новый отчёт и привязать к текущему сообщению)");
+            log.info("Отчёта с новой датой не существует (новый отчёт и привязать к текущему сообщению)");
 
             Report savedReport = reportRepository.save(updatedReport);
             currentMessage.setReport(savedReport);
             chatMessageRepository.save(currentMessage);
-
-            deleteNewTemporaryReport(updatedReport);
 
             setMessageTextForUserReportDone(messageForUser, updatedReport);
             setMessageTextForReportsChatReportDone(messageForReportsChat, updatedReport);
@@ -147,48 +114,68 @@ public class SetReportDateTimeCallbackStrategy implements CallbackStrategy {
 
     private void handleNewMessage(SendMessage messageForUser, SendMessage messageForReportsChat, Update update, Report updatedReport, Integer messageId) {
         if (reportRepository.existsReportByDateAndStudentUserName(updatedReport.getDate(), updatedReport.getStudentUserName())) {
-            log.debug("Отчёт с новой датой существует (обновить его, удалить старое сообщение и сохранить новое сообщение с переданным айди в БД с этим отчётом)");
+            log.info("Отчёт с такой датой ({}) существует (обновить его)", updatedReport.getDate().format(defaultDateFormatter()));
             List<Report> existingReportsOnReceivedDate = reportRepository.findByDateAndStudentUserName(updatedReport.getDate(), updatedReport.getStudentUserName());
             Report reportLikeReceived = existingReportsOnReceivedDate.get(0);
             deleteDuplicateReports(existingReportsOnReceivedDate);
+
+            log.info("Старый отчёт обновлён");
             updateReportFromAnotherReport(updatedReport, reportLikeReceived);
 
             ChatMessage oldMessage = chatMessageRepository.findChatMessageByReport(reportLikeReceived);
 
-            ChatMessage newMessage = ChatMessage.builder()
-                    .userMessageId(messageId)
-                    .report(reportLikeReceived)
-                    .build();
-            if (oldMessage.getReportChatBotMessageId() != null) {
-                newMessage.setReportChatBotMessageId(oldMessage.getReportChatBotMessageId());
+            if (oldMessage != null && oldMessage.getReportChatBotMessageId() != null) {
+                log.info("К старому отчёту уже было привязано сообщение в БД");
+                oldMessage.setReport(reportLikeReceived);
+                oldMessage.setUserMessageId(messageId);
+                log.info("К сообщению в БД привязан старый отчёт(с обновлёнными данными) и сообщение-отчёт от пользователя");
+
+                chatMessageRepository.save(oldMessage);
+
+                deleteNewTemporaryReport(updatedReport);
+
+                messageForUser.setText(String.format("Вы обновили существующий отчёт за %s:\n@%s\n%s\n%s\n%s",
+                        reportLikeReceived.getDate().format(defaultDateFormatter()),
+                        updatedReport.getStudentUserName(),
+                        updatedReport.getDate().format(defaultDateFormatter()),
+                        updatedReport.getHours(),
+                        updatedReport.getTitle()
+                ));
+                setMessageTextReportIsUpdated(messageForReportsChat, updatedReport);
+            } else if (oldMessage == null) {
+                log.info("К старому отчёту не было привязано сообщение в БД");
+
+                ChatMessage newMessage = ChatMessage.builder()
+                        .report(reportLikeReceived)
+                        .userMessageId(messageId)
+                        .build();
+                chatMessageRepository.save(newMessage);
+                log.info("К старому отчёту теперь привязано сообщение в БД");
+
+                deleteNewTemporaryReport(updatedReport);
+
+                messageForUser.setText(String.format("Вы обновили существующий отчёт за %s:\n@%s\n%s\n%s\n%s",
+                        reportLikeReceived.getDate().format(defaultDateFormatter()),
+                        updatedReport.getStudentUserName(),
+                        updatedReport.getDate().format(defaultDateFormatter()),
+                        updatedReport.getHours(),
+                        updatedReport.getTitle()
+                ));
+                messageForReportsChat.setText(String.format("Пользователь обновил существующий отчёт за %s:\n@%s\n%s\n%s\n%s",
+                        reportLikeReceived.getDate().format(defaultDateFormatter()),
+                        updatedReport.getStudentUserName(),
+                        updatedReport.getDate().format(defaultDateFormatter()),
+                        updatedReport.getHours(),
+                        updatedReport.getTitle()
+                ));
             }
-            chatMessageRepository.save(newMessage);
-            chatMessageRepository.delete(oldMessage);
-
-            deleteNewTemporaryReport(updatedReport);
-
-            messageForUser.setText(String.format("Вы обновили существующий отчёт за %s:\n@%s\n%s\n%s\n%s",
-                    LocalDate.now().format(defaultDateFormatter()),
-                    updatedReport.getStudentUserName(),
-                    updatedReport.getDate().format(defaultDateFormatter()),
-                    updatedReport.getHours(),
-                    updatedReport.getTitle()
-            ));
-            setMessageTextReportIsUpdated(messageForReportsChat, updatedReport);
         } else {
-            log.debug("Отчёта с новой датой не существует (новый отчёт и сохранить новое сообщение с переданным айди в БД с этим отчётом)");
+            log.info("Отчёта с новой датой не существует (сохранить новый отчёт и новое сообщение в БД)");
             saveNewReport(messageForUser, messageForReportsChat, update, updatedReport, messageId);
 
             setMessageTextForUserReportDone(messageForUser, updatedReport);
             setMessageTextForReportsChatReportDone(messageForReportsChat, updatedReport);
         }
-    }
-
-    private boolean isExistingReportEqualsReportFromCurrentMessage(ChatMessage chatMessage, Report updatedReport) {
-        List<Report> existingReportsWithSuchDate = reportRepository.findByDateAndStudentUserName(updatedReport.getDate(), updatedReport.getStudentUserName());
-        Report reportLikeReceived = existingReportsWithSuchDate.get(0);
-        deleteDuplicateReports(existingReportsWithSuchDate);
-        return chatMessage.getReport().equals(reportLikeReceived);
     }
 
     private void deleteDuplicateReports(List<Report> existingReports) {
@@ -208,7 +195,7 @@ public class SetReportDateTimeCallbackStrategy implements CallbackStrategy {
     }
 
     private void deleteNewTemporaryReport(Report report) {
-        reportRepository.deleteById(report.getId());
+        reportRepository.findById(report.getId()).ifPresent(reportRepository::delete);
     }
 
     private void saveNewReport(SendMessage messageForUser, SendMessage messageForReportsChat, Update update, Report report, Integer messageId) {

--- a/src/main/java/com/nekromant/telegram/commands/report/ReportCommand.java
+++ b/src/main/java/com/nekromant/telegram/commands/report/ReportCommand.java
@@ -1,7 +1,6 @@
 package com.nekromant.telegram.commands.report;
 
 import com.nekromant.telegram.commands.MentoringReviewWithMessageIdCommand;
-import com.nekromant.telegram.contants.CallBack;
 import com.nekromant.telegram.model.Report;
 import com.nekromant.telegram.repository.ReportRepository;
 import com.nekromant.telegram.service.UserInfoService;
@@ -12,23 +11,12 @@ import org.springframework.stereotype.Component;
 import org.telegram.telegrambots.meta.api.methods.send.SendMessage;
 import org.telegram.telegrambots.meta.api.objects.Chat;
 import org.telegram.telegrambots.meta.api.objects.User;
-import org.telegram.telegrambots.meta.api.objects.replykeyboard.InlineKeyboardMarkup;
-import org.telegram.telegrambots.meta.api.objects.replykeyboard.buttons.InlineKeyboardButton;
 import org.telegram.telegrambots.meta.bots.AbsSender;
-import org.telegram.telegrambots.meta.exceptions.TelegramApiException;
 
 import java.security.InvalidParameterException;
-import java.time.LocalDate;
-import java.time.ZoneId;
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.Collections;
-import java.util.List;
-import java.util.stream.Collectors;
 
 import static com.nekromant.telegram.contants.Command.REPORT;
 import static com.nekromant.telegram.contants.MessageContants.*;
-import static com.nekromant.telegram.utils.FormatterUtils.defaultDateFormatter;
 import static com.nekromant.telegram.utils.ValidationUtils.validateArgumentsNumber;
 
 @Slf4j
@@ -41,6 +29,8 @@ public class ReportCommand extends MentoringReviewWithMessageIdCommand {
     private UserInfoService userInfoService;
     @Autowired
     private SendMessageFactory sendMessageFactory;
+    @Autowired
+    private ReportDateTimePicker reportDateTimePicker;
 
     public ReportCommand() {
         super(REPORT.getAlias(), REPORT.getDescription());
@@ -58,13 +48,10 @@ public class ReportCommand extends MentoringReviewWithMessageIdCommand {
                 //тут убрать когда получу все chatId, оставить только в /start
                 userInfoService.initializeUserInfo(chat, user);
 
-                Report report = new Report();
-                report.setHours(parseHours(strings));
-                report.setStudentUserName(user.getUserName());
-                report.setTitle(parseTitle(strings));
+                Report report = Report.getTemporaryReport(strings, user.getUserName());
 
                 reportRepository.save(report);
-                sendDatePicker(absSender, user.getId().toString(), report, messageId);
+                absSender.execute(reportDateTimePicker.sendDatePicker(user.getId().toString(), report, messageId));
             } catch (InvalidParameterException e) {
                 log.error(e.getMessage(), e);
                 sendAnswer(chat.getId().toString(), e.getMessage() + "\n" + REPORT_HELP_MESSAGE, absSender, user);
@@ -81,56 +68,5 @@ public class ReportCommand extends MentoringReviewWithMessageIdCommand {
     private void sendAnswer(String chatId, String text, AbsSender absSender, User user) {
         SendMessage message = sendMessageFactory.create(chatId, text);
         execute(absSender, message, user);
-    }
-
-    private String parseTitle(String[] strings) {
-        return Arrays.stream(strings).skip(1).collect(Collectors.joining(" "));
-    }
-
-    private Integer parseHours(String[] strings) {
-        int hours = Integer.parseInt(strings[0]);
-        validateHoursArgument(hours);
-        return hours;
-    }
-
-    private void validateHoursArgument(int hours) {
-        if (hours < 0 || hours > 24) {
-            throw new InvalidParameterException("Неверное значение часов — должно быть от 0 до 24");
-        }
-    }
-
-    private void sendDatePicker(AbsSender absSender, String userChatId, Report report, Integer messageId) throws TelegramApiException {
-        InlineKeyboardMarkup inlineKeyboardMarkup = getDatePickerInlineKeyboardMarkup(report, messageId);
-        SendMessage message = sendMessageFactory.create(userChatId, "Выберите дату");
-        message.setReplyMarkup(inlineKeyboardMarkup);
-        absSender.execute(message);
-    }
-
-    private InlineKeyboardMarkup getDatePickerInlineKeyboardMarkup(Report report, Integer messageId) {
-        InlineKeyboardMarkup inlineKeyboardMarkup = new InlineKeyboardMarkup();
-        List<List<InlineKeyboardButton>> keyboardRows = new ArrayList<>();
-
-        LocalDate currentDay = LocalDate.now(ZoneId.of("Europe/Moscow"));
-        addDateButton(keyboardRows, report, currentDay.minusDays(1), messageId);
-        addDateButton(keyboardRows, report, currentDay, messageId);
-        addCancelButton(keyboardRows, report);
-
-        inlineKeyboardMarkup.setKeyboard(keyboardRows);
-        return inlineKeyboardMarkup;
-    }
-
-    private void addDateButton(List<List<InlineKeyboardButton>> keyboardRows, Report report, LocalDate date, Integer messageId) {
-        String dateString = date.format(defaultDateFormatter());
-        InlineKeyboardButton dateButton = new InlineKeyboardButton();
-        dateButton.setText(dateString);
-        dateButton.setCallbackData(String.join(" ", CallBack.SET_REPORT_DATE_TIME.getAlias(), dateString, report.getId().toString(), messageId.toString()));
-        keyboardRows.add(Collections.singletonList(dateButton));
-    }
-
-    private void addCancelButton(List<List<InlineKeyboardButton>> keyboardRows, Report report) {
-        InlineKeyboardButton cancelButton = new InlineKeyboardButton();
-        cancelButton.setText("Отмена");
-        cancelButton.setCallbackData(String.join(" ", CallBack.DENY_REPORT_DATE_TIME.getAlias(), report.getId().toString()));
-        keyboardRows.add(Collections.singletonList(cancelButton));
     }
 }

--- a/src/main/java/com/nekromant/telegram/commands/report/ReportCommand.java
+++ b/src/main/java/com/nekromant/telegram/commands/report/ReportCommand.java
@@ -3,6 +3,7 @@ package com.nekromant.telegram.commands.report;
 import com.nekromant.telegram.commands.MentoringReviewWithMessageIdCommand;
 import com.nekromant.telegram.model.Report;
 import com.nekromant.telegram.repository.ReportRepository;
+import com.nekromant.telegram.service.ReportService;
 import com.nekromant.telegram.service.UserInfoService;
 import com.nekromant.telegram.utils.SendMessageFactory;
 import lombok.extern.slf4j.Slf4j;
@@ -31,6 +32,8 @@ public class ReportCommand extends MentoringReviewWithMessageIdCommand {
     private SendMessageFactory sendMessageFactory;
     @Autowired
     private ReportDateTimePicker reportDateTimePicker;
+    @Autowired
+    private ReportService reportService;
 
     public ReportCommand() {
         super(REPORT.getAlias(), REPORT.getDescription());
@@ -48,7 +51,7 @@ public class ReportCommand extends MentoringReviewWithMessageIdCommand {
                 //тут убрать когда получу все chatId, оставить только в /start
                 userInfoService.initializeUserInfo(chat, user);
 
-                Report report = Report.getTemporaryReport(strings, user.getUserName());
+                Report report = reportService.getTemporaryReport(strings, user.getUserName());
 
                 reportRepository.save(report);
                 absSender.execute(reportDateTimePicker.getDatePickerSendMessage(user.getId().toString(), report, messageId));

--- a/src/main/java/com/nekromant/telegram/commands/report/ReportCommand.java
+++ b/src/main/java/com/nekromant/telegram/commands/report/ReportCommand.java
@@ -51,7 +51,7 @@ public class ReportCommand extends MentoringReviewWithMessageIdCommand {
                 Report report = Report.getTemporaryReport(strings, user.getUserName());
 
                 reportRepository.save(report);
-                absSender.execute(reportDateTimePicker.sendDatePicker(user.getId().toString(), report, messageId));
+                absSender.execute(reportDateTimePicker.getDatePickerSendMessage(user.getId().toString(), report, messageId));
             } catch (InvalidParameterException e) {
                 log.error(e.getMessage(), e);
                 sendAnswer(chat.getId().toString(), e.getMessage() + "\n" + REPORT_HELP_MESSAGE, absSender, user);

--- a/src/main/java/com/nekromant/telegram/commands/report/ReportDateTimePicker.java
+++ b/src/main/java/com/nekromant/telegram/commands/report/ReportDateTimePicker.java
@@ -22,7 +22,7 @@ public class ReportDateTimePicker {
     @Autowired
     private SendMessageFactory sendMessageFactory;
 
-    public SendMessage sendDatePicker(String userChatId, Report report, Integer messageId) {
+    public SendMessage getDatePickerSendMessage(String userChatId, Report report, Integer messageId) {
         InlineKeyboardMarkup inlineKeyboardMarkup = getDatePickerInlineKeyboardMarkup(report, messageId);
         SendMessage message = sendMessageFactory.create(userChatId, "Выберите дату");
         message.setReplyMarkup(inlineKeyboardMarkup);

--- a/src/main/java/com/nekromant/telegram/commands/report/ReportDateTimePicker.java
+++ b/src/main/java/com/nekromant/telegram/commands/report/ReportDateTimePicker.java
@@ -1,0 +1,59 @@
+package com.nekromant.telegram.commands.report;
+
+import com.nekromant.telegram.contants.CallBack;
+import com.nekromant.telegram.model.Report;
+import com.nekromant.telegram.utils.SendMessageFactory;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Component;
+import org.telegram.telegrambots.meta.api.methods.send.SendMessage;
+import org.telegram.telegrambots.meta.api.objects.replykeyboard.InlineKeyboardMarkup;
+import org.telegram.telegrambots.meta.api.objects.replykeyboard.buttons.InlineKeyboardButton;
+
+import java.time.LocalDate;
+import java.time.ZoneId;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
+import static com.nekromant.telegram.utils.FormatterUtils.defaultDateFormatter;
+
+@Component
+public class ReportDateTimePicker {
+    @Autowired
+    private SendMessageFactory sendMessageFactory;
+
+    public SendMessage sendDatePicker(String userChatId, Report report, Integer messageId) {
+        InlineKeyboardMarkup inlineKeyboardMarkup = getDatePickerInlineKeyboardMarkup(report, messageId);
+        SendMessage message = sendMessageFactory.create(userChatId, "Выберите дату");
+        message.setReplyMarkup(inlineKeyboardMarkup);
+        return message;
+    }
+
+    private InlineKeyboardMarkup getDatePickerInlineKeyboardMarkup(Report report, Integer messageId) {
+        InlineKeyboardMarkup inlineKeyboardMarkup = new InlineKeyboardMarkup();
+        List<List<InlineKeyboardButton>> keyboardRows = new ArrayList<>();
+
+        LocalDate currentDay = LocalDate.now(ZoneId.of("Europe/Moscow"));
+        addDateButton(keyboardRows, report, currentDay.minusDays(1), messageId);
+        addDateButton(keyboardRows, report, currentDay, messageId);
+        addCancelButton(keyboardRows, report);
+
+        inlineKeyboardMarkup.setKeyboard(keyboardRows);
+        return inlineKeyboardMarkup;
+    }
+
+    private void addDateButton(List<List<InlineKeyboardButton>> keyboardRows, Report report, LocalDate date, Integer messageId) {
+        String dateString = date.format(defaultDateFormatter());
+        InlineKeyboardButton dateButton = new InlineKeyboardButton();
+        dateButton.setText(dateString);
+        dateButton.setCallbackData(String.join(" ", CallBack.SET_REPORT_DATE_TIME.getAlias(), dateString, report.getId().toString(), messageId.toString()));
+        keyboardRows.add(Collections.singletonList(dateButton));
+    }
+
+    private void addCancelButton(List<List<InlineKeyboardButton>> keyboardRows, Report report) {
+        InlineKeyboardButton cancelButton = new InlineKeyboardButton();
+        cancelButton.setText("Отмена");
+        cancelButton.setCallbackData(String.join(" ", CallBack.DENY_REPORT_DATE_TIME.getAlias(), report.getId().toString()));
+        keyboardRows.add(Collections.singletonList(cancelButton));
+    }
+}

--- a/src/main/java/com/nekromant/telegram/model/ChatMessage.java
+++ b/src/main/java/com/nekromant/telegram/model/ChatMessage.java
@@ -6,7 +6,7 @@ import javax.persistence.*;
 import javax.validation.constraints.NotNull;
 
 /**
- * Представляет собой связь между сообщениями чата и отчётом.
+ * Представляет собой связь между сообщением пользователя, отчётом в БД и сообщениями бота в чате пользователя и чате отчётов
  */
 @Entity
 @AllArgsConstructor

--- a/src/main/java/com/nekromant/telegram/model/Report.java
+++ b/src/main/java/com/nekromant/telegram/model/Report.java
@@ -1,13 +1,9 @@
 package com.nekromant.telegram.model;
 
 import lombok.*;
-import org.telegram.telegrambots.meta.api.objects.Update;
 
 import javax.persistence.*;
-import java.security.InvalidParameterException;
 import java.time.LocalDate;
-import java.util.Arrays;
-import java.util.stream.Collectors;
 
 @Entity
 @Data
@@ -32,45 +28,4 @@ public class Report {
 
     @Column
     private String title;
-
-    public static void updateReportFromEditedMessage(String editedText, Report report) {
-        String[] strings = editedText.split(" ");
-        strings = Arrays.copyOfRange(strings, 1, strings.length);
-
-        report.setHours(parseHours(strings));
-        report.setTitle(parseTitle(strings));
-    }
-
-    public static Report getTemporaryReport(Update update) {
-        String[] strings = update.getEditedMessage().getText().split(" ");
-        strings = Arrays.copyOfRange(strings, 1, strings.length);
-
-        String userName = update.getEditedMessage().getFrom().getUserName();
-        return getTemporaryReport(strings, userName);
-    }
-
-    public static Report getTemporaryReport(String[] strings, String userName) {
-        Report report = new Report();
-
-        report.setHours(parseHours(strings));
-        report.setTitle(parseTitle(strings));
-        report.setStudentUserName(userName);
-        return report;
-    }
-
-    private static int parseHours(String[] strings) {
-        int newHours = Integer.parseInt(strings[0]);
-        validateHoursArgument(newHours);
-        return newHours;
-    }
-
-    private static String parseTitle(String[] strings) {
-        return Arrays.stream(strings).skip(1).collect(Collectors.joining(" "));
-    }
-
-    private static void validateHoursArgument(int hours) {
-        if (hours < 0 || hours > 24) {
-            throw new InvalidParameterException("Неверное значение часов — должно быть от 0 до 24");
-        }
-    }
 }

--- a/src/main/java/com/nekromant/telegram/model/Report.java
+++ b/src/main/java/com/nekromant/telegram/model/Report.java
@@ -1,17 +1,13 @@
 package com.nekromant.telegram.model;
 
-import lombok.AllArgsConstructor;
-import lombok.Builder;
-import lombok.Data;
-import lombok.NoArgsConstructor;
-import lombok.ToString;
+import lombok.*;
+import org.telegram.telegrambots.meta.api.objects.Update;
 
-import javax.persistence.Column;
-import javax.persistence.Entity;
-import javax.persistence.GeneratedValue;
-import javax.persistence.GenerationType;
-import javax.persistence.Id;
+import javax.persistence.*;
+import java.security.InvalidParameterException;
 import java.time.LocalDate;
+import java.util.Arrays;
+import java.util.stream.Collectors;
 
 @Entity
 @Data
@@ -36,4 +32,45 @@ public class Report {
 
     @Column
     private String title;
+
+    public static void updateReportFromEditedMessage(String editedText, Report report) {
+        String[] strings = editedText.split(" ");
+        strings = Arrays.copyOfRange(strings, 1, strings.length);
+
+        report.setHours(parseHours(strings));
+        report.setTitle(parseTitle(strings));
+    }
+
+    public static Report getTemporaryReport(Update update) {
+        String[] strings = update.getEditedMessage().getText().split(" ");
+        strings = Arrays.copyOfRange(strings, 1, strings.length);
+
+        String userName = update.getEditedMessage().getFrom().getUserName();
+        return getTemporaryReport(strings, userName);
+    }
+
+    public static Report getTemporaryReport(String[] strings, String userName) {
+        Report report = new Report();
+
+        report.setHours(parseHours(strings));
+        report.setTitle(parseTitle(strings));
+        report.setStudentUserName(userName);
+        return report;
+    }
+
+    private static int parseHours(String[] strings) {
+        int newHours = Integer.parseInt(strings[0]);
+        validateHoursArgument(newHours);
+        return newHours;
+    }
+
+    private static String parseTitle(String[] strings) {
+        return Arrays.stream(strings).skip(1).collect(Collectors.joining(" "));
+    }
+
+    private static void validateHoursArgument(int hours) {
+        if (hours < 0 || hours > 24) {
+            throw new InvalidParameterException("Неверное значение часов — должно быть от 0 до 24");
+        }
+    }
 }


### PR DESCRIPTION
Раньше редактирование всегда происходило через превращения отредактированного сообщения в новое и обработки его соответствующим образом.
Теперь редактирование отчётов и новые сообщения об отчётах могут обрабатываться по разному.
Большинство if в методе processEditedMessageUpdate нужны лишь для случаев, когда в БД закорапчены данные.
Основной метод тут это handleExistingReport. Благодаря ему в большинстве случаев теперь не требуется указывать дату отчёта при редактировании.
Для реализации этого потребовалось вытащить DateTimePicker из ReportCommand в отдельный компонент.
Также потребовалось часто создавать в коде Report, что дублировало код в классе ReportCommand - вынес все необходимые методы в класс Report.