### PR TITLE
Safari redirect issue

### DIFF
--- a/src/main/resources/static/css/pricing.css
+++ b/src/main/resources/static/css/pricing.css
@@ -544,6 +544,12 @@ a {
     text-transform: capitalize;
 }
 
+.form__footer__note {
+    font-size: 14px;
+    color: aliceblue;
+    margin-top: 10px;
+}
+
 @media (max-width: 1200px) {
     .first-block .first-block__title {
         width: 378px;

--- a/src/main/resources/static/js/pricing.js
+++ b/src/main/resources/static/js/pricing.js
@@ -185,7 +185,7 @@ async function submit_new_client_cv_roasting() {
             }
             throw new Error('Что-то пошло не так :(');
         })
-        .then(text => window.open(text).focus())
+        .then(text => window.open(text, '_blank'))
         .catch((error => {
             alert(error)
         }));
@@ -253,7 +253,7 @@ async function submit_new_client_mentoringSubscription() {
                 throw new Error('Что-то пошло не так :(');
             }
         })
-        .then(text => window.open(text).focus())
+        .then(text => window.open(text, '_blank'))
         .catch((error => {
             alert(error)
         }));
@@ -321,7 +321,7 @@ async function submit_new_client_personalCall() {
                 throw new Error('Что-то пошло не так :(');
             }
         })
-        .then(text => window.open(text).focus())
+        .then(text => window.open(text, '_blank'))
         .catch((error => {
             alert(error)
         }));

--- a/src/main/resources/templates/pricing.html
+++ b/src/main/resources/templates/pricing.html
@@ -236,6 +236,12 @@
             <div class="form__footer">
                 <button class="button" id="pay-button">оплатить</button>
             </div>
+            <div class="form__footer__note">
+                Если Вы используете браузер Safari, то перед оплатой убедитесь,
+                что <a href="https://support.apple.com/ru-ru/102524" target="_blank">
+                <strong>отключена блокировка всплывающих окон</strong></a>.
+                Это необходимо для перехода на странцу СБП и последующей оплаты.
+            </div>
         </form>
     </div>
 </section>


### PR DESCRIPTION
При работе с браузером Safari не происходил редирект на страницу СБП с указанием на null в функции .focus().

Решение сохранило исходный функционал для браузеров Chrome, Firefox, Edge, Yandex.
При подтверждении решения об оплате для Safari всплывает требование подтверждения о переходе.