### PR TITLE
Фикс несовместимости кодировок

### DIFF
--- a/src/main/java/com/nekromant/telegram/controller/PricingRestController.java
+++ b/src/main/java/com/nekromant/telegram/controller/PricingRestController.java
@@ -10,6 +10,8 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 import org.springframework.web.multipart.MultipartFile;
 
+import java.net.URLDecoder;
+import java.nio.charset.StandardCharsets;
 import java.util.Map;
 
 @RestController
@@ -30,6 +32,9 @@ public class PricingRestController {
                                                          @RequestHeader("TG-NAME") String tgName,
                                                          @RequestHeader("PHONE") String phone,
                                                          @RequestHeader("CV-PROMOCODE-ID") String CVPromocodeId) throws Exception {
+        tgName = URLDecoder.decode(tgName, StandardCharsets.UTF_8);
+        phone = URLDecoder.decode(phone, StandardCharsets.UTF_8);
+        CVPromocodeId = URLDecoder.decode(CVPromocodeId, StandardCharsets.UTF_8);
         return resumeAnalysisRequestService.save(formData.getBytes(), tgName, phone, CVPromocodeId);
     }
 

--- a/src/main/resources/static/js/pricing.js
+++ b/src/main/resources/static/js/pricing.js
@@ -163,15 +163,13 @@ async function submit_new_client_cv_roasting() {
     const form_data = new FormData();
     form_data.append("form_data", file);
 
-    const headers = {
-        'TG-NAME': tgName,
-        'PHONE': phone
-    };
-
-    if (cvPromocodeId!== null) {
-        headers['CV-PROMOCODE-ID'] = cvPromocodeId;
+    const headers = new Headers();
+    headers.append('TG-NAME', encodeURIComponent(tgName));
+    headers.append('PHONE', encodeURIComponent(phone));
+    if (cvPromocodeId !== null) {
+        headers.append('CV-PROMOCODE-ID', encodeURIComponent(cvPromocodeId))
     } else {
-        headers['CV-PROMOCODE-ID'] = null;
+        headers.append('CV-PROMOCODE-ID', encodeURIComponent(null))
     }
 
     await fetch("./pricing/cv", {


### PR DESCRIPTION
Фиксил исключение "failed to read the 'headers' property from 'RequestInit': String contains non ISO-8859-1 code point", вызванное нестандартной кодировкой.