### PR TITLE
Изменения по замечаниям к предыдущему пр и )

### DIFF
--- a/src/main/java/com/nekromant/telegram/controller/PaymentDetailsRestController.java
+++ b/src/main/java/com/nekromant/telegram/controller/PaymentDetailsRestController.java
@@ -80,4 +80,4 @@ public class PaymentDetailsRestController {
                 .append("Имя плательщика: ").append(paymentDetails.getCardHolder()).append("\n")
                 .append("Дата транзакции: ").append(paymentDetails.getCreated()).append("\n").toString();
     }
-}
+}   

--- a/src/main/java/com/nekromant/telegram/controller/PaymentDetailsRestController.java
+++ b/src/main/java/com/nekromant/telegram/controller/PaymentDetailsRestController.java
@@ -80,4 +80,4 @@ public class PaymentDetailsRestController {
                 .append("Имя плательщика: ").append(paymentDetails.getCardHolder()).append("\n")
                 .append("Дата транзакции: ").append(paymentDetails.getCreated()).append("\n").toString();
     }
-}   
+}

--- a/src/main/java/com/nekromant/telegram/controller/PricingController.java
+++ b/src/main/java/com/nekromant/telegram/controller/PricingController.java
@@ -1,10 +1,18 @@
 package com.nekromant.telegram.controller;
 
+import com.nekromant.telegram.model.UtmTag;
+import com.nekromant.telegram.service.UtmTagsService;
+import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Controller;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+
+import javax.servlet.http.HttpServletResponse;
 
 @Controller
+@RequiredArgsConstructor
 public class PricingController {
+    private final UtmTagsService utmTagsService;
 
     @GetMapping
     public String redirectToPricing() {
@@ -12,7 +20,12 @@ public class PricingController {
     }
 
     @GetMapping("/pricing")
-    public String getPricingPage() {
+    public String getPricingPage(@RequestParam(required = false) String source,
+                                 HttpServletResponse response) {
+        if (source != null) {
+            UtmTag tag = utmTagsService.getTag(source, UtmTag.PRICE_SECTION);
+            response.addCookie(utmTagsService.setCookieByUtmTag(tag));
+        }
         return "pricing";
     }
 

--- a/src/main/java/com/nekromant/telegram/controller/PricingRestController.java
+++ b/src/main/java/com/nekromant/telegram/controller/PricingRestController.java
@@ -1,15 +1,18 @@
 package com.nekromant.telegram.controller;
 
 import com.nekromant.telegram.config.PriceProperties;
+import com.nekromant.telegram.model.UtmTag;
 import com.nekromant.telegram.service.MentoringSubscriptionRequestService;
 import com.nekromant.telegram.service.PersonalCallRequestService;
 import com.nekromant.telegram.service.ResumeAnalysisRequestService;
+import com.nekromant.telegram.service.UtmTagsService;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 import org.springframework.web.multipart.MultipartFile;
 
+import javax.servlet.http.HttpServletRequest;
 import java.net.URLDecoder;
 import java.nio.charset.StandardCharsets;
 import java.util.Map;
@@ -25,27 +28,34 @@ public class PricingRestController {
     private PersonalCallRequestService personalCallRequestService;
     @Autowired
     private PriceProperties priceProperties;
+    @Autowired
+    private UtmTagsService utmTagsService;
+
 
     @PostMapping("/cv")
     @Modifying
     public ResponseEntity submitNewResumeAnalysisRequest(@RequestParam("form_data") MultipartFile formData,
                                                          @RequestHeader("TG-NAME") String tgName,
                                                          @RequestHeader("PHONE") String phone,
-                                                         @RequestHeader("CV-PROMOCODE-ID") String CVPromocodeId) throws Exception {
+                                                         @RequestHeader("CV-PROMOCODE-ID") String CVPromocodeId,
+                                                         HttpServletRequest request) throws Exception {
+        UtmTag  tag = utmTagsService.getUtmSourceFromCookies(request);
         tgName = URLDecoder.decode(tgName, StandardCharsets.UTF_8);
         phone = URLDecoder.decode(phone, StandardCharsets.UTF_8);
         CVPromocodeId = URLDecoder.decode(CVPromocodeId, StandardCharsets.UTF_8);
-        return resumeAnalysisRequestService.save(formData.getBytes(), tgName, phone, CVPromocodeId);
+        return resumeAnalysisRequestService.save(formData.getBytes(), tgName, phone, CVPromocodeId, tag);
     }
 
     @PostMapping("/mentoring")
-    public ResponseEntity submitNewMentoringSubscription(@RequestBody Map mentoringData) {
-        return mentoringSubscriptionRequestService.save(mentoringData);
+    public ResponseEntity submitNewMentoringSubscription(@RequestBody Map mentoringData, HttpServletRequest request) {
+        UtmTag  tag = utmTagsService.getUtmSourceFromCookies(request);
+        return mentoringSubscriptionRequestService.save(mentoringData, tag);
     }
 
     @PostMapping("/call")
-    public ResponseEntity submitNewCall(@RequestBody Map callData) {
-        return personalCallRequestService.save(callData);
+    public ResponseEntity submitNewCall(@RequestBody Map callData, HttpServletRequest request) {
+        UtmTag  tag = utmTagsService.getUtmSourceFromCookies(request);
+        return personalCallRequestService.save(callData, tag);
     }
 
     @GetMapping("/cv/price")

--- a/src/main/java/com/nekromant/telegram/model/PaymentDetails.java
+++ b/src/main/java/com/nekromant/telegram/model/PaymentDetails.java
@@ -102,4 +102,8 @@ public class PaymentDetails {
     @Type(type = "OrderJsonType")
     @Column(name = "td_order")
     private OrderDTO order;
+
+    @ManyToOne
+    @JoinColumn(name = "utm_tag_id")
+    private UtmTag utmTag;
 }

--- a/src/main/java/com/nekromant/telegram/model/UtmTag.java
+++ b/src/main/java/com/nekromant/telegram/model/UtmTag.java
@@ -1,0 +1,31 @@
+package com.nekromant.telegram.model;
+
+import lombok.*;
+
+
+import javax.persistence.Entity;
+import javax.persistence.GeneratedValue;
+import javax.persistence.GenerationType;
+import javax.persistence.Id;
+
+@Entity
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class UtmTag {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    private String source;
+
+    private Integer valueClick;
+
+    private String section;
+
+    public static String PRICE_SECTION = "price_section";
+
+    public static String PAY_REQUEST = "pay_request";
+}

--- a/src/main/java/com/nekromant/telegram/model/UtmTag.java
+++ b/src/main/java/com/nekromant/telegram/model/UtmTag.java
@@ -7,6 +7,7 @@ import javax.persistence.Entity;
 import javax.persistence.GeneratedValue;
 import javax.persistence.GenerationType;
 import javax.persistence.Id;
+import java.time.LocalDateTime;
 
 @Entity
 @Data
@@ -21,7 +22,7 @@ public class UtmTag {
 
     private String source;
 
-    private Integer valueClick;
+    private LocalDateTime localDateTime;
 
     private String section;
 

--- a/src/main/java/com/nekromant/telegram/repository/UtmTagRepository.java
+++ b/src/main/java/com/nekromant/telegram/repository/UtmTagRepository.java
@@ -1,0 +1,11 @@
+package com.nekromant.telegram.repository;
+
+import com.nekromant.telegram.model.UtmTag;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
+
+public interface UtmTagRepository extends JpaRepository<UtmTag, Long> {
+
+    Optional<UtmTag> getUtmTagsBySourceAndSection(String source, String section);
+}

--- a/src/main/java/com/nekromant/telegram/service/ClientPaymentRequestServiceCommon.java
+++ b/src/main/java/com/nekromant/telegram/service/ClientPaymentRequestServiceCommon.java
@@ -10,6 +10,7 @@ import com.nekromant.telegram.contants.ServiceType;
 import com.nekromant.telegram.model.ClientPaymentRequest;
 import com.nekromant.telegram.model.PaymentDetails;
 import com.nekromant.telegram.model.Promocode;
+import com.nekromant.telegram.model.UtmTag;
 import com.nekromant.telegram.repository.PaymentDetailsRepository;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -41,7 +42,7 @@ public class ClientPaymentRequestServiceCommon {
     private SendMessageService sendMessageService;
 
 
-    public ResponseEntity save(ServiceType serviceType, ChequeDTO chequeDTO, ClientPaymentRequest paymentRequest, CrudRepository repository, String promocodeId) {
+    public ResponseEntity save(ServiceType serviceType, ChequeDTO chequeDTO, ClientPaymentRequest paymentRequest, CrudRepository repository, String promocodeId, UtmTag utmTag) {
 
         try {
             log.info("Sending request to LifePay: {}", chequeDTO);
@@ -52,6 +53,7 @@ public class ClientPaymentRequestServiceCommon {
                     .number(lifePayResponse.getData().getNumber())
                     .status(PayStatus.UNREDEEMED)
                     .serviceType(serviceType)
+                    .utmTag(utmTag)
                     .build();
             paymentDetailsRepository.save(paymentDetails);
             log.info("Unredeemed payment created: {}", paymentDetails);

--- a/src/main/java/com/nekromant/telegram/service/MentoringSubscriptionRequestService.java
+++ b/src/main/java/com/nekromant/telegram/service/MentoringSubscriptionRequestService.java
@@ -6,6 +6,7 @@ import com.nekromant.telegram.config.PriceProperties;
 import com.nekromant.telegram.contants.ServiceType;
 import com.nekromant.telegram.model.MentoringSubscriptionRequest;
 import com.nekromant.telegram.model.PaymentDetails;
+import com.nekromant.telegram.model.UtmTag;
 import com.nekromant.telegram.repository.MentoringSubscriptionRequestRepository;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -27,7 +28,7 @@ public class MentoringSubscriptionRequestService extends ClientPaymentRequestSer
     @Autowired
     private PriceProperties priceProperties;
 
-    public ResponseEntity save(Map mentoringData) {
+    public ResponseEntity save(Map mentoringData, UtmTag tag) {
         MentoringSubscriptionRequest mentoringSubscriptionRequest = MentoringSubscriptionRequest.builder()
                 .tgName(mentoringData.get("TG-NAME").toString())
                 .customerPhone(mentoringData.get("PHONE").toString())
@@ -40,7 +41,7 @@ public class MentoringSubscriptionRequestService extends ClientPaymentRequestSer
                 mentoringData.get("PHONE").toString(),
                 lifePayProperties.getMethod());
 
-        return save(ServiceType.MENTORING, chequeDTO, mentoringSubscriptionRequest, mentoringSubscriptionRequestRepository, promocodeId);
+        return save(ServiceType.MENTORING, chequeDTO, mentoringSubscriptionRequest, mentoringSubscriptionRequestRepository, promocodeId, tag);
     }
 
     public void notifyMentor(PaymentDetails paymentDetails) {

--- a/src/main/java/com/nekromant/telegram/service/PersonalCallRequestService.java
+++ b/src/main/java/com/nekromant/telegram/service/PersonalCallRequestService.java
@@ -6,6 +6,7 @@ import com.nekromant.telegram.config.PriceProperties;
 import com.nekromant.telegram.contants.ServiceType;
 import com.nekromant.telegram.model.PaymentDetails;
 import com.nekromant.telegram.model.PersonalCallRequest;
+import com.nekromant.telegram.model.UtmTag;
 import com.nekromant.telegram.repository.PersonalCallRequestRepository;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.ResponseEntity;
@@ -26,7 +27,7 @@ public class PersonalCallRequestService extends ClientPaymentRequestServiceCommo
     @Autowired
     private PriceProperties priceProperties;
 
-    public ResponseEntity save(Map callData) {
+    public ResponseEntity save(Map callData, UtmTag utmTag) {
         PersonalCallRequest personalCallRequest = PersonalCallRequest.builder()
                 .tgName(callData.get("TG-NAME").toString())
                 .customerPhone(callData.get("PHONE").toString())
@@ -39,7 +40,7 @@ public class PersonalCallRequestService extends ClientPaymentRequestServiceCommo
                 callData.get("PHONE").toString(),
                 lifePayProperties.getMethod());
 
-        return save(ServiceType.CALL, chequeDTO, personalCallRequest, personalCallRequestRepository, promocodeId);
+        return save(ServiceType.CALL, chequeDTO, personalCallRequest, personalCallRequestRepository, promocodeId, utmTag);
     }
 
     @Override

--- a/src/main/java/com/nekromant/telegram/service/ResumeAnalysisRequestService.java
+++ b/src/main/java/com/nekromant/telegram/service/ResumeAnalysisRequestService.java
@@ -7,6 +7,7 @@ import com.nekromant.telegram.config.PriceProperties;
 import com.nekromant.telegram.contants.ServiceType;
 import com.nekromant.telegram.model.PaymentDetails;
 import com.nekromant.telegram.model.ResumeAnalysisRequest;
+import com.nekromant.telegram.model.UtmTag;
 import com.nekromant.telegram.repository.ResumeAnalysisRequestRepository;
 import feign.form.FormData;
 import lombok.extern.slf4j.Slf4j;
@@ -39,7 +40,7 @@ public class ResumeAnalysisRequestService extends ClientPaymentRequestServiceCom
     @Autowired
     private PriceProperties priceProperties;
 
-    public ResponseEntity save(byte[] CVPdf, String tgName, String phone, String promocodeId) {
+    public ResponseEntity save(byte[] CVPdf, String tgName, String phone, String promocodeId, UtmTag utmTag) {
         ResumeAnalysisRequest resumeAnalysisRequest = ResumeAnalysisRequest.builder()
                 .CVPdf(CVPdf)
                 .tgName(tgName)
@@ -53,7 +54,7 @@ public class ResumeAnalysisRequestService extends ClientPaymentRequestServiceCom
                 phone,
                 lifePayProperties.getMethod());
 
-        return save(ServiceType.RESUME, chequeDTO, resumeAnalysisRequest, resumeAnalysisRequestRepository, promocodeId);
+        return save(ServiceType.RESUME, chequeDTO, resumeAnalysisRequest, resumeAnalysisRequestRepository, promocodeId, utmTag);
     }
 
     public void notifyMentor(PaymentDetails paymentDetails) {

--- a/src/main/java/com/nekromant/telegram/service/UtmTagsService.java
+++ b/src/main/java/com/nekromant/telegram/service/UtmTagsService.java
@@ -7,7 +7,7 @@ import org.springframework.stereotype.Service;
 
 import javax.servlet.http.Cookie;
 import javax.servlet.http.HttpServletRequest;
-import javax.servlet.http.HttpServletResponse;
+import java.time.LocalDateTime;
 import java.util.Arrays;
 
 @Service
@@ -22,38 +22,32 @@ public class UtmTagsService {
             return null;
         }
 
-        UtmTag tag = Arrays.stream(cookies)
+        return Arrays.stream(cookies)
                 .filter(cookie -> "utm_source".equals(cookie.getName()))
                 .findFirst()
                 .map(cookie -> getTag(cookie.getValue(), UtmTag.PAY_REQUEST))
                 .orElse(null);
+    }
+
+
+    public UtmTag getTag(String source, String section) {
+        UtmTag tag = UtmTag.builder()
+                .section(section)
+                .localDateTime(LocalDateTime.now())
+                .source(source)
+                .build();
+
+        utmTagRepository.save(tag);
+
         return tag;
     }
 
-
-    public UtmTag getTag(String tag, String section) {
-        UtmTag tagEntity = utmTagRepository.getUtmTagsBySourceAndSection(tag, section)
-                .map(existingTag -> {
-                    existingTag.setValueClick(existingTag.getValueClick() + 1);
-                    return existingTag;
-                })
-                .orElseGet(() -> UtmTag.builder()
-                        .source(tag)
-                        .valueClick(1)
-                        .section(section)
-                        .build());
-
-        utmTagRepository.save(tagEntity);
-
-        return tagEntity;
-    }
-
-    public Cookie setCookieByUtmTag(UtmTag utmTag){
-        if(utmTag != null){
+    public Cookie setCookieByUtmTag(UtmTag utmTag) {
+        if (utmTag != null) {
             Cookie sourceCookie = new Cookie("utm_source", utmTag.getSource());
             sourceCookie.setPath("/");
             sourceCookie.setMaxAge(60 * 60 * 24 * 30);
-            return  sourceCookie;
+            return sourceCookie;
         }
         return null;
     }

--- a/src/main/java/com/nekromant/telegram/service/UtmTagsService.java
+++ b/src/main/java/com/nekromant/telegram/service/UtmTagsService.java
@@ -1,0 +1,61 @@
+package com.nekromant.telegram.service;
+
+import com.nekromant.telegram.model.UtmTag;
+import com.nekromant.telegram.repository.UtmTagRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import javax.servlet.http.Cookie;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import java.util.Arrays;
+
+@Service
+@RequiredArgsConstructor
+public class UtmTagsService {
+
+    private final UtmTagRepository utmTagRepository;
+
+    public UtmTag getUtmSourceFromCookies(HttpServletRequest request) {
+        Cookie[] cookies = request.getCookies();
+        if (cookies == null) {
+            return null;
+        }
+
+        UtmTag tag = Arrays.stream(cookies)
+                .filter(cookie -> "utm_source".equals(cookie.getName()))
+                .findFirst()
+                .map(cookie -> getTag(cookie.getValue(), UtmTag.PAY_REQUEST))
+                .orElse(null);
+        return tag;
+    }
+
+
+    public UtmTag getTag(String tag, String section) {
+        UtmTag tagEntity = utmTagRepository.getUtmTagsBySourceAndSection(tag, section)
+                .map(existingTag -> {
+                    existingTag.setValueClick(existingTag.getValueClick() + 1);
+                    return existingTag;
+                })
+                .orElseGet(() -> UtmTag.builder()
+                        .source(tag)
+                        .valueClick(1)
+                        .section(section)
+                        .build());
+
+        utmTagRepository.save(tagEntity);
+
+        return tagEntity;
+    }
+
+    public Cookie setCookieByUtmTag(UtmTag utmTag){
+        if(utmTag != null){
+            Cookie sourceCookie = new Cookie("utm_source", utmTag.getSource());
+            sourceCookie.setPath("/");
+            sourceCookie.setMaxAge(60 * 60 * 24 * 30);
+            return  sourceCookie;
+        }
+        return null;
+    }
+
+}

--- a/src/main/resources/db/changelog/db.changelog-master.xml
+++ b/src/main/resources/db/changelog/db.changelog-master.xml
@@ -12,4 +12,6 @@
     <include file="/db/changelog/v1.0.0/006-db.changelog-addUserInfoFKColumnToStepPassed.xml"/>
     <include file="/db/changelog/v1.0.0/007-db.changelog-addUserInfoFKColumnToSalary.xml"/>
     <include file="/db/changelog/v1.0.0/008-db.changelog-addUserInfoFKColumnToContract.xml"/>
+    <include file="/db/changelog/v1.0.0/009-db.changelog-addUtmTagsTable.xml"/>
+    <include file="/db/changelog/v1.0.0/010-db.changelog-addColumnUtmTagInPaymentDetails.xml"/>
 </databaseChangeLog>

--- a/src/main/resources/db/changelog/v1.0.0/009-db.changelog-addUtmTagsTable.xml
+++ b/src/main/resources/db/changelog/v1.0.0/009-db.changelog-addUtmTagsTable.xml
@@ -1,0 +1,29 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<databaseChangeLog xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+                   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                   xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
+                   https://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-latest.xsd">
+
+    <changeSet id="create-utm-tag-table" author="m004ka">
+        <preConditions onFail="MARK_RAN">
+            <not>
+                <tableExists tableName="utm_tag"/>
+            </not>
+        </preConditions>
+
+        <createTable tableName="utm_tag">
+            <column name="id" type="BIGINT" autoIncrement="true">
+                <constraints primaryKey="true" nullable="false"/>
+            </column>
+            <column name="source" type="VARCHAR(255)">
+                <constraints nullable="true"/>
+            </column>
+            <column name="value_click" type="INT">
+                <constraints nullable="true"/>
+            </column>
+            <column name="section" type="VARCHAR(255)">
+                <constraints nullable="true"/>
+            </column>
+        </createTable>
+    </changeSet>
+</databaseChangeLog>

--- a/src/main/resources/db/changelog/v1.0.0/009-db.changelog-addUtmTagsTable.xml
+++ b/src/main/resources/db/changelog/v1.0.0/009-db.changelog-addUtmTagsTable.xml
@@ -18,7 +18,7 @@
             <column name="source" type="VARCHAR(255)">
                 <constraints nullable="true"/>
             </column>
-            <column name="value_click" type="INT">
+            <column name="local_date_time" type="TIMESTAMP">
                 <constraints nullable="true"/>
             </column>
             <column name="section" type="VARCHAR(255)">

--- a/src/main/resources/db/changelog/v1.0.0/010-db.changelog-addColumnUtmTagInPaymentDetails.xml
+++ b/src/main/resources/db/changelog/v1.0.0/010-db.changelog-addColumnUtmTagInPaymentDetails.xml
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<databaseChangeLog xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+                   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                   xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
+                   https://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-latest.xsd">
+
+    <changeSet id="add-utm-tag-to-payment-details" author="m004ka">
+        <preConditions onFail="MARK_RAN">
+            <not>
+                <columnExists tableName="payment_details" columnName="utm_tag_id"/>
+            </not>
+        </preConditions>
+
+        <addColumn tableName="payment_details">
+            <column name="utm_tag_id" type="BIGINT"/>
+        </addColumn>
+
+        <addForeignKeyConstraint
+                baseTableName="payment_details"
+                baseColumnNames="utm_tag_id"
+                referencedTableName="utm_tag"
+                referencedColumnNames="id"
+                constraintName="fk_payment_details_utm_tag"/>
+    </changeSet>
+
+</databaseChangeLog>


### PR DESCRIPTION
Написаны миграции для db.changelog
Исправлены замечания (пустой коммит с пробелами)
Теперь utm-метки имеют не количество кликов по определенному ресурсу. А каждая utm метка сохраняется индивидуально и запоминает свое время LocalDateTIme