### PR TITLE
Add notification subscription command

### DIFF
--- a/src/main/java/com/nekromant/telegram/commands/notification/DisablePayNotification.java
+++ b/src/main/java/com/nekromant/telegram/commands/notification/DisablePayNotification.java
@@ -1,0 +1,57 @@
+package com.nekromant.telegram.commands.notification;
+
+import com.nekromant.telegram.commands.MentoringReviewCommand;
+import com.nekromant.telegram.contants.MessageContants;
+import com.nekromant.telegram.model.Mentor;
+import com.nekromant.telegram.repository.MentorRepository;
+import com.nekromant.telegram.service.NotificationService;
+import com.nekromant.telegram.utils.ValidationUtils;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Component;
+import org.telegram.telegrambots.meta.api.methods.send.SendMessage;
+import org.telegram.telegrambots.meta.api.objects.Chat;
+import org.telegram.telegrambots.meta.api.objects.User;
+import org.telegram.telegrambots.meta.bots.AbsSender;
+
+import java.security.InvalidParameterException;
+
+import static com.nekromant.telegram.contants.Command.DISABLE_NOTIFICATION;
+
+@Component
+public class DisablePayNotification extends MentoringReviewCommand {
+
+    @Autowired
+    private MentorRepository mentorRepository;
+    @Autowired
+    private NotificationService notificationService;
+
+    public DisablePayNotification() {
+        super(DISABLE_NOTIFICATION.getAlias(), DISABLE_NOTIFICATION.getDescription());
+    }
+
+    @Override
+    public void execute(AbsSender absSender, User user, Chat chat, String[] strings) {
+        SendMessage message = new SendMessage();
+        String chatId = chat.getId().toString();
+        message.setChatId(chatId);
+        ValidationUtils.validateArgumentsNumber(strings);
+
+        try {
+            Mentor mentor = mentorRepository.findMentorByMentorInfo_ChatId(user.getId());
+            if (mentor == null) {
+                message.setText("Ты не ментор");
+                execute(absSender, message, user);
+            } else {
+                notificationService.disablePayNotification(strings);
+                message.setText(MessageContants.SUCCESS_SET_NOTIFICATION);
+                execute(absSender, message, user);
+            }
+        } catch (InvalidParameterException e) {
+            message.setText("Укажи аргументы");
+            execute(absSender, message, user);
+        } catch (Exception e) {
+            message.setText(MessageContants.FAILED_SET_NOTIFICATION);
+            execute(absSender, message, user);
+        }
+    }
+}

--- a/src/main/java/com/nekromant/telegram/commands/notification/DisablePayNotification.java
+++ b/src/main/java/com/nekromant/telegram/commands/notification/DisablePayNotification.java
@@ -2,11 +2,11 @@ package com.nekromant.telegram.commands.notification;
 
 import com.nekromant.telegram.commands.MentoringReviewCommand;
 import com.nekromant.telegram.contants.MessageContants;
-import com.nekromant.telegram.model.Mentor;
-import com.nekromant.telegram.repository.MentorRepository;
 import com.nekromant.telegram.service.NotificationService;
 import com.nekromant.telegram.utils.ValidationUtils;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Component;
 import org.telegram.telegrambots.meta.api.methods.send.SendMessage;
 import org.telegram.telegrambots.meta.api.objects.Chat;
@@ -17,13 +17,15 @@ import java.security.InvalidParameterException;
 
 import static com.nekromant.telegram.contants.Command.DISABLE_NOTIFICATION;
 
+@Slf4j
 @Component
 public class DisablePayNotification extends MentoringReviewCommand {
 
     @Autowired
-    private MentorRepository mentorRepository;
-    @Autowired
     private NotificationService notificationService;
+
+    @Value("${owner.userName}")
+    private String ownerUserName;
 
     public DisablePayNotification() {
         super(DISABLE_NOTIFICATION.getAlias(), DISABLE_NOTIFICATION.getDescription());
@@ -31,26 +33,26 @@ public class DisablePayNotification extends MentoringReviewCommand {
 
     @Override
     public void execute(AbsSender absSender, User user, Chat chat, String[] strings) {
+        log.info("Выключение уведомлений об оплате подписки для пользователей");
         SendMessage message = new SendMessage();
         String chatId = chat.getId().toString();
         message.setChatId(chatId);
         ValidationUtils.validateArgumentsNumber(strings);
 
         try {
-            Mentor mentor = mentorRepository.findMentorByMentorInfo_ChatId(user.getId());
-            if (mentor == null) {
-                message.setText("Ты не ментор");
+            if (!chat.getUserName().equals(ownerUserName)) {
+                message.setText("Ты не владелец бота");
                 execute(absSender, message, user);
             } else {
                 notificationService.disablePayNotification(strings);
-                message.setText(MessageContants.SUCCESS_SET_NOTIFICATION);
+                message.setText(MessageContants.SUCCESS_DISABLE_NOTIFICATION);
                 execute(absSender, message, user);
             }
         } catch (InvalidParameterException e) {
             message.setText("Укажи аргументы");
             execute(absSender, message, user);
         } catch (Exception e) {
-            message.setText(MessageContants.FAILED_SET_NOTIFICATION);
+            message.setText(MessageContants.FAILED_DISABLE_NOTIFICATION);
             execute(absSender, message, user);
         }
     }

--- a/src/main/java/com/nekromant/telegram/commands/notification/EnablePayNotification.java
+++ b/src/main/java/com/nekromant/telegram/commands/notification/EnablePayNotification.java
@@ -2,11 +2,11 @@ package com.nekromant.telegram.commands.notification;
 
 import com.nekromant.telegram.commands.MentoringReviewCommand;
 import com.nekromant.telegram.contants.MessageContants;
-import com.nekromant.telegram.model.Mentor;
-import com.nekromant.telegram.repository.MentorRepository;
 import com.nekromant.telegram.service.NotificationService;
 import com.nekromant.telegram.utils.ValidationUtils;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Component;
 import org.telegram.telegrambots.meta.api.methods.send.SendMessage;
 import org.telegram.telegrambots.meta.api.objects.Chat;
@@ -17,13 +17,15 @@ import java.security.InvalidParameterException;
 
 import static com.nekromant.telegram.contants.Command.ENABLE_NOTIFICATION;
 
+@Slf4j
 @Component
 public class EnablePayNotification extends MentoringReviewCommand {
 
     @Autowired
-    private MentorRepository mentorRepository;
-    @Autowired
     private NotificationService notificationService;
+
+    @Value("${owner.userName}")
+    private String ownerUserName;
 
     public EnablePayNotification() {
         super(ENABLE_NOTIFICATION.getAlias(), ENABLE_NOTIFICATION.getDescription());
@@ -31,26 +33,26 @@ public class EnablePayNotification extends MentoringReviewCommand {
 
     @Override
     public void execute(AbsSender absSender, User user, Chat chat, String[] strings) {
+        log.info("Включение уведомлений об оплате подписки для пользователей");
         SendMessage message = new SendMessage();
         String chatId = chat.getId().toString();
         message.setChatId(chatId);
         ValidationUtils.validateArgumentsNumber(strings);
 
         try {
-            Mentor mentor = mentorRepository.findMentorByMentorInfo_ChatId(user.getId());
-            if (mentor == null) {
-                message.setText("Ты не ментор");
+            if (!chat.getUserName().equals(ownerUserName)) {
+                message.setText("Ты не владелец бота");
                 execute(absSender, message, user);
             } else {
                 notificationService.enablePayNotification(strings);
-                message.setText(MessageContants.SUCCESS_SET_NOTIFICATION);
+                message.setText(MessageContants.SUCCESS_ENABLE_NOTIFICATION);
                 execute(absSender, message, user);
             }
         } catch (InvalidParameterException e) {
             message.setText("Укажи аргументы");
             execute(absSender, message, user);
         } catch (Exception e) {
-            message.setText(MessageContants.FAILED_SET_NOTIFICATION);
+            message.setText(MessageContants.FAILED_ENABLE_NOTIFICATION);
             execute(absSender, message, user);
         }
     }

--- a/src/main/java/com/nekromant/telegram/commands/notification/EnablePayNotification.java
+++ b/src/main/java/com/nekromant/telegram/commands/notification/EnablePayNotification.java
@@ -1,0 +1,57 @@
+package com.nekromant.telegram.commands.notification;
+
+import com.nekromant.telegram.commands.MentoringReviewCommand;
+import com.nekromant.telegram.contants.MessageContants;
+import com.nekromant.telegram.model.Mentor;
+import com.nekromant.telegram.repository.MentorRepository;
+import com.nekromant.telegram.service.NotificationService;
+import com.nekromant.telegram.utils.ValidationUtils;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Component;
+import org.telegram.telegrambots.meta.api.methods.send.SendMessage;
+import org.telegram.telegrambots.meta.api.objects.Chat;
+import org.telegram.telegrambots.meta.api.objects.User;
+import org.telegram.telegrambots.meta.bots.AbsSender;
+
+import java.security.InvalidParameterException;
+
+import static com.nekromant.telegram.contants.Command.ENABLE_NOTIFICATION;
+
+@Component
+public class EnablePayNotification extends MentoringReviewCommand {
+
+    @Autowired
+    private MentorRepository mentorRepository;
+    @Autowired
+    private NotificationService notificationService;
+
+    public EnablePayNotification() {
+        super(ENABLE_NOTIFICATION.getAlias(), ENABLE_NOTIFICATION.getDescription());
+    }
+
+    @Override
+    public void execute(AbsSender absSender, User user, Chat chat, String[] strings) {
+        SendMessage message = new SendMessage();
+        String chatId = chat.getId().toString();
+        message.setChatId(chatId);
+        ValidationUtils.validateArgumentsNumber(strings);
+
+        try {
+            Mentor mentor = mentorRepository.findMentorByMentorInfo_ChatId(user.getId());
+            if (mentor == null) {
+                message.setText("Ты не ментор");
+                execute(absSender, message, user);
+            } else {
+                notificationService.enablePayNotification(strings);
+                message.setText(MessageContants.SUCCESS_SET_NOTIFICATION);
+                execute(absSender, message, user);
+            }
+        } catch (InvalidParameterException e) {
+            message.setText("Укажи аргументы");
+            execute(absSender, message, user);
+        } catch (Exception e) {
+            message.setText(MessageContants.FAILED_SET_NOTIFICATION);
+            execute(absSender, message, user);
+        }
+    }
+}

--- a/src/main/java/com/nekromant/telegram/contants/Command.java
+++ b/src/main/java/com/nekromant/telegram/contants/Command.java
@@ -27,7 +27,9 @@ public enum Command {
     PAY("pay", "Оплатить чек"),
     GET_CONTRACTS("get_contracts", "Посмотреть все контракты"),
     DAILY("daily", "Назначить ежедневное уведомление"),
-    DAILY_DELETE("daily_delete", "Удалить ежедневное уведомление");
+    DAILY_DELETE("daily_delete", "Удалить ежедневное уведомление"),
+    ENABLE_NOTIFICATION("/add_reminder", "Включить уведеомленя о платежах для пользователей"),
+    DISABLE_NOTIFICATION("/remove_reminder", "Выключить уведеомленя о платежах для пользователей");
 
     private String alias;
     private String description;

--- a/src/main/java/com/nekromant/telegram/contants/MessageContants.java
+++ b/src/main/java/com/nekromant/telegram/contants/MessageContants.java
@@ -52,4 +52,8 @@ public class MessageContants {
 
     public static final String RESPONSE_FOR_PERSONAL_CALL = "Зарегистрирован и оплачен заказ %s на личный созвон: \nтелефон: %s \nTelegram nickname: %s";
     public static final String PERSONAL_CALL_DESCRIPTION = "Оплата за персональный созвон ПО ДОГОВОРУ ПУБЛ ОФЕРТЫ";
+
+    public static final String NOTIFICATION_FOR_USERS = "Привет, решил напомнить, что накормить моего хозяина можно командой /pay";
+    public static final String SUCCESS_SET_NOTIFICATION = "Уведомления для пользователей успешно выключены";
+    public static final String FAILED_SET_NOTIFICATION = "Уведомления для пользователей не выключены - произошла ошибка";
 }

--- a/src/main/java/com/nekromant/telegram/contants/MessageContants.java
+++ b/src/main/java/com/nekromant/telegram/contants/MessageContants.java
@@ -54,6 +54,8 @@ public class MessageContants {
     public static final String PERSONAL_CALL_DESCRIPTION = "Оплата за персональный созвон ПО ДОГОВОРУ ПУБЛ ОФЕРТЫ";
 
     public static final String NOTIFICATION_FOR_USERS = "Привет, решил напомнить, что накормить моего хозяина можно командой /pay";
-    public static final String SUCCESS_SET_NOTIFICATION = "Уведомления для пользователей успешно выключены";
-    public static final String FAILED_SET_NOTIFICATION = "Уведомления для пользователей не выключены - произошла ошибка";
+    public static final String SUCCESS_ENABLE_NOTIFICATION = "Уведомления для пользователей успешно включены";
+    public static final String FAILED_ENABLE_NOTIFICATION = "Уведомления для пользователей не включены - произошла ошибка";
+    public static final String SUCCESS_DISABLE_NOTIFICATION = "Уведомления для пользователей успешно выключены";
+    public static final String FAILED_DISABLE_NOTIFICATION = "Уведомления для пользователей не вылючены - произошла ошибка";
 }

--- a/src/main/java/com/nekromant/telegram/model/NotificationPay.java
+++ b/src/main/java/com/nekromant/telegram/model/NotificationPay.java
@@ -1,0 +1,23 @@
+package com.nekromant.telegram.model;
+
+import lombok.*;
+
+import javax.persistence.*;
+
+@Entity
+@Builder
+@RequiredArgsConstructor
+@AllArgsConstructor
+@Data
+public class NotificationPay {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @OneToOne
+    @JoinColumn(name = "chat_id", referencedColumnName = "chatId")
+    private UserInfo userInfo;
+
+    private boolean enable;
+}

--- a/src/main/java/com/nekromant/telegram/repository/ContractRepository.java
+++ b/src/main/java/com/nekromant/telegram/repository/ContractRepository.java
@@ -8,4 +8,5 @@ import java.util.Optional;
 public interface ContractRepository extends CrudRepository<Contract, String> {
     Optional<Contract> findContractByStudentInfo_UserName(String username);
     Optional<Contract> findContractByStudentInfo_chatId(Long chatId);
+    Optional<Contract> findContractByContractId(String contractId);
 }

--- a/src/main/java/com/nekromant/telegram/repository/NotificationPayRepository.java
+++ b/src/main/java/com/nekromant/telegram/repository/NotificationPayRepository.java
@@ -1,0 +1,11 @@
+package com.nekromant.telegram.repository;
+
+import com.nekromant.telegram.model.NotificationPay;
+import com.nekromant.telegram.model.UserInfo;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+public interface NotificationPayRepository extends JpaRepository<NotificationPay, Long> {
+    NotificationPay getNotificationPayByUserInfo(UserInfo userInfo);
+    List<NotificationPay> getNotificationPayByEnable(Boolean type);
+}

--- a/src/main/java/com/nekromant/telegram/repository/PaymentDetailsRepository.java
+++ b/src/main/java/com/nekromant/telegram/repository/PaymentDetailsRepository.java
@@ -1,10 +1,17 @@
 package com.nekromant.telegram.repository;
 
 import com.nekromant.telegram.model.PaymentDetails;
+import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.CrudRepository;
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
+
+import java.util.List;
 
 @Repository
 public interface PaymentDetailsRepository extends CrudRepository<PaymentDetails, Long> {
     PaymentDetails findByNumber(String number);
+
+    @Query(value = "SELECT * FROM payment_details WHERE created >= :start AND created < :end", nativeQuery = true)
+    List<PaymentDetails> findAllByCreatedAtBetween(@Param("start") String start, @Param("end") String end);
 }

--- a/src/main/java/com/nekromant/telegram/service/NotificationService.java
+++ b/src/main/java/com/nekromant/telegram/service/NotificationService.java
@@ -1,0 +1,84 @@
+package com.nekromant.telegram.service;
+
+import com.nekromant.telegram.model.NotificationPay;
+import com.nekromant.telegram.model.UserInfo;
+import com.nekromant.telegram.repository.NotificationPayRepository;
+import com.nekromant.telegram.repository.UserInfoRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Service
+@RequiredArgsConstructor
+public class NotificationService {
+
+    private final NotificationPayRepository notificationPayRepository;
+    private final UserInfoRepository userInfoRepository;
+
+    public void enablePayNotification(String[] strings) {
+        List<UserInfo> userInfoList = getUsers(extractUsernames(strings));
+
+        List<NotificationPay> notificationPayList = new ArrayList<>();
+        for (UserInfo user : userInfoList) {
+            NotificationPay pay = getNotification(user);
+            pay.setEnable(true);
+            notificationPayList.add(pay);
+        }
+        saveNotificationChanges(notificationPayList);
+    }
+
+    public void disablePayNotification(String[] strings) {
+        List<UserInfo> userInfoList = getUsers(extractUsernames(strings));
+
+        List<NotificationPay> notificationPayList = new ArrayList<>();
+        for (UserInfo user : userInfoList) {
+            NotificationPay pay = getNotification(user);
+            pay.setEnable(false);
+            notificationPayList.add(pay);
+        }
+        saveNotificationChanges(notificationPayList);
+    }
+
+    public NotificationPay getNotification(UserInfo userInfo) {
+        NotificationPay notificationPay;
+
+        try {
+            notificationPay = notificationPayRepository.getNotificationPayByUserInfo(userInfo);
+            if (notificationPay == null) {
+                notificationPay = NotificationPay.builder()
+                        .userInfo(userInfo)
+                        .build();
+            }
+        } catch (Exception e) {
+            notificationPay = NotificationPay.builder()
+                    .userInfo(userInfo)
+                    .build();
+        }
+
+        return notificationPay;
+    }
+
+    private void saveNotificationChanges(List<NotificationPay> notificationPayList) {
+        notificationPayRepository.saveAll(notificationPayList);
+    }
+
+    public List<String> extractUsernames(String[] strings) {
+        return Arrays.stream(strings)
+                .filter(part -> part.startsWith("@") && part.length() > 1)
+                .map(part -> part.substring(1))
+                .collect(Collectors.toList());
+    }
+
+    public List<UserInfo> getUsers(List<String> users) {
+        List<UserInfo> userInfoList = new ArrayList<>();
+        for (String username : users) {
+            userInfoList.add(userInfoRepository.findUserInfoByUserName(username));
+        }
+
+        return userInfoList;
+    }
+}

--- a/src/main/java/com/nekromant/telegram/sheduler/NotificationScheduler.java
+++ b/src/main/java/com/nekromant/telegram/sheduler/NotificationScheduler.java
@@ -7,6 +7,7 @@ import com.nekromant.telegram.model.UserInfo;
 import com.nekromant.telegram.repository.*;
 import com.nekromant.telegram.service.SendMessageService;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Component;
@@ -19,6 +20,7 @@ import java.util.Objects;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
+@Slf4j
 @Component
 @RequiredArgsConstructor
 public class NotificationScheduler {
@@ -33,6 +35,7 @@ public class NotificationScheduler {
 
     @Scheduled(cron = "0 0 13 L * ?")
     private void sendNotificationPay() {
+        log.info("Ежемесячное уведомление пользователей не оплативших подписку");
         init();
     }
 

--- a/src/main/java/com/nekromant/telegram/sheduler/NotificationScheduler.java
+++ b/src/main/java/com/nekromant/telegram/sheduler/NotificationScheduler.java
@@ -1,0 +1,96 @@
+package com.nekromant.telegram.sheduler;
+
+import com.nekromant.telegram.contants.MessageContants;
+import com.nekromant.telegram.model.NotificationPay;
+import com.nekromant.telegram.model.PaymentDetails;
+import com.nekromant.telegram.model.UserInfo;
+import com.nekromant.telegram.repository.*;
+import com.nekromant.telegram.service.SendMessageService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+
+import java.time.YearMonth;
+import java.time.ZoneOffset;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Objects;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+@Component
+@RequiredArgsConstructor
+public class NotificationScheduler {
+
+    private final NotificationPayRepository notificationPayRepository;
+    private final PaymentDetailsRepository paymentDetailsRepository;
+    private final ContractRepository contractRepository;
+    private final SendMessageService sendMessageService;
+
+    @Value("${price.mentoring-subscription}")
+    private String valueSubscription;
+
+    @Scheduled(cron = "0 0 13 L * ?")
+    private void sendNotificationPay() {
+        init();
+    }
+
+    private void init() {
+        List<NotificationPay> notificationPayList = notificationPayRepository.getNotificationPayByEnable(true);
+        List<UserInfo> userList = new ArrayList<>();
+
+        for (NotificationPay notification : notificationPayList) {
+            userList.add(notification.getUserInfo());
+        }
+
+        List<PaymentDetails> paymentList = getPaymentsForCurrentMonth();
+        for (PaymentDetails pay : paymentList) {
+            if (hasContractNumber(pay.getDescription()) && Objects.equals(pay.getAmount(), valueSubscription)) {
+                userList.remove(contractRepository.findContractByContractId(getContractId(pay)).orElseThrow(() -> new RuntimeException("Contract not found")).getStudentInfo());
+            }
+        }
+
+        sendNotification(userList);
+    }
+
+    private void sendNotification(List<UserInfo> userInfoList) {
+        for (UserInfo user : userInfoList) {
+            sendMessageService.sendMessage(user.getChatId().toString(), MessageContants.NOTIFICATION_FOR_USERS);
+        }
+    }
+
+    private String getContractId(PaymentDetails pay) {
+        String description = pay.getDescription();
+        Matcher matcher = Pattern.compile("\\b(\\d+)\\b").matcher(description);
+        if (matcher.find()) {
+            return matcher.group(1);
+        }
+        return "none";
+    }
+
+    public boolean hasContractNumber(String description) {
+        if (description == null) {
+            return false;
+        }
+        Matcher matcher = Pattern.compile("договору\\s+(\\d+)").matcher(description);
+        return matcher.find();
+    }
+
+    public List<PaymentDetails> getPaymentsForCurrentMonth() {
+        YearMonth current = YearMonth.now();
+
+        String start = current.atDay(1)
+                .atStartOfDay(ZoneOffset.UTC)
+                .toOffsetDateTime()
+                .toString();
+
+        String end = current.plusMonths(1)
+                .atDay(1)
+                .atStartOfDay(ZoneOffset.UTC)
+                .toOffsetDateTime()
+                .toString();
+
+        return paymentDetailsRepository.findAllByCreatedAtBetween(start, end);
+    }
+}

--- a/src/main/resources/db/changelog/v1.0.0/012-db.changelog-new-Entity-NotificationPay.xml
+++ b/src/main/resources/db/changelog/v1.0.0/012-db.changelog-new-Entity-NotificationPay.xml
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<databaseChangeLog xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+                   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                   xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
+                   https://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-latest.xsd">
+
+    <changeSet id="Notification-Pay-entity" author="m004ka">
+
+        <createTable tableName="notification_pay">
+            <column name="id" type="BIGINT" autoIncrement="true">
+                <constraints primaryKey="true" nullable="false"/>
+            </column>
+
+            <column name="chat_id" type="BIGINT">
+                <constraints nullable="false" unique="true" foreignKeyName="fk_notification_pay_userinfo"
+                             referencedTableName="user_info" referencedColumnNames="chat_id"/>
+            </column>
+
+            <column name="enable" type="BOOLEAN">
+                <constraints nullable="false"/>
+            </column>
+        </createTable>
+
+    </changeSet>
+</databaseChangeLog>


### PR DESCRIPTION
Сервис который уведомляет пользователей не оплативших подписку об оплате.
/add_reminder - Включить уведеомленя о платежах для пользователей
/remove_reminder - Выключить уведеомленя о платежах для пользователей
(Обе команды затем получают список пользователей в формате (/add_reminder пробел @тгЮзернейм пробел @тгЮзернейм и т. д.) - если включать уведомления больше чем одному пользователю
Для одного пользователя пример: "/remove_reminder @тгЮзернейм"

Сервис уведомляет пользователей не оплативших подписку в последний день месяца в 13:00

Проверка оплаты пользователем происходит путем загрузки всех платежей за месяц и последующим их парсингом по id контракта, которое содержится в описании платежа. И если сервис находит оплату подписки пользователя, то он исключает его из списка уведомляемых.
(Список уведомляемых состоит из тех пользователей, которых ментор в него добавит командой /add_reminder)