### PR TITLE
Добавил команды для вкл/выкл уведомлений в чате менторов

### DIFF
--- a/src/main/java/com/nekromant/telegram/commands/notification/DisableReportNotification.java
+++ b/src/main/java/com/nekromant/telegram/commands/notification/DisableReportNotification.java
@@ -1,0 +1,54 @@
+package com.nekromant.telegram.commands.notification;
+
+import com.nekromant.telegram.commands.MentoringReviewCommand;
+import com.nekromant.telegram.service.NotificationReportService;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+import org.telegram.telegrambots.meta.api.methods.send.SendMessage;
+import org.telegram.telegrambots.meta.api.objects.Chat;
+import org.telegram.telegrambots.meta.api.objects.User;
+import org.telegram.telegrambots.meta.bots.AbsSender;
+
+import static com.nekromant.telegram.contants.Command.NOTIFY_REPORT_OFF;
+
+@Slf4j
+@Component
+public class DisableReportNotification extends MentoringReviewCommand {
+
+    @Autowired
+    private NotificationReportService notificationReportService;
+
+    @Value("${owner.userName}")
+    private String ownerUserName;
+
+    public DisableReportNotification() {
+        super(NOTIFY_REPORT_OFF.getAlias(), NOTIFY_REPORT_OFF.getDescription());
+    }
+
+    @Override
+    public void execute(AbsSender absSender, User user, Chat chat, String[] arguments) {
+        log.info("Выключение уведомлений о пользователях, ненаписавших отчет");
+        SendMessage message = new SendMessage();
+        String chatId = chat.getId().toString();
+        message.setChatId(chatId);
+
+        if (!user.getUserName().equals(ownerUserName)) {
+            message.setText("Ты не владелец бота");
+            execute(absSender, message, user);
+            return;
+        }
+
+        try {
+            notificationReportService.disableReportNotification();
+            message.setText("Уведомления о пользователях, ненаписавших отчет отключены");
+            execute(absSender, message, user);
+        } catch (Exception e) {
+            message.setText("Что-то пошло не так " + e.getMessage());
+            execute(absSender, message, user);
+        }
+
+
+    }
+}

--- a/src/main/java/com/nekromant/telegram/commands/notification/EnableReportNotification.java
+++ b/src/main/java/com/nekromant/telegram/commands/notification/EnableReportNotification.java
@@ -1,0 +1,53 @@
+package com.nekromant.telegram.commands.notification;
+
+import com.nekromant.telegram.commands.MentoringReviewCommand;
+import com.nekromant.telegram.service.NotificationReportService;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+import org.telegram.telegrambots.meta.api.methods.send.SendMessage;
+import org.telegram.telegrambots.meta.api.objects.Chat;
+import org.telegram.telegrambots.meta.api.objects.User;
+import org.telegram.telegrambots.meta.bots.AbsSender;
+
+import static com.nekromant.telegram.contants.Command.NOTIFY_REPORT_ON;
+
+
+@Slf4j
+@Component
+public class EnableReportNotification extends MentoringReviewCommand {
+    @Autowired
+    private NotificationReportService notificationReportService;
+
+    @Value("${owner.userName}")
+    private String ownerUserName;
+
+    public EnableReportNotification() {
+        super(NOTIFY_REPORT_ON.getAlias(), NOTIFY_REPORT_ON.getDescription());
+    }
+
+    @Override
+    public void execute(AbsSender absSender, User user, Chat chat, String[] arguments) {
+        log.info("Включение уведомлений о пользователях, ненаписавших отчет");
+        SendMessage message = new SendMessage();
+        String chatId = chat.getId().toString();
+        message.setChatId(chatId);
+
+        if (!user.getUserName().equals(ownerUserName)) {
+            message.setText("Ты не владелец бота");
+            execute(absSender, message, user);
+            return;
+        }
+
+        try {
+            notificationReportService.enableReportNotification();
+            message.setText("Уведомления о пользователях, ненаписавших отчет включены");
+            execute(absSender, message, user);
+        } catch (Exception e) {
+            message.setText("Что-то пошло не так " + e.getMessage());
+            execute(absSender, message, user);
+        }
+    }
+}
+

--- a/src/main/java/com/nekromant/telegram/contants/Command.java
+++ b/src/main/java/com/nekromant/telegram/contants/Command.java
@@ -29,7 +29,9 @@ public enum Command {
     DAILY("daily", "Назначить ежедневное уведомление"),
     DAILY_DELETE("daily_delete", "Удалить ежедневное уведомление"),
     ENABLE_NOTIFICATION("/add_reminder", "Включить уведеомленя о платежах для пользователей"),
-    DISABLE_NOTIFICATION("/remove_reminder", "Выключить уведеомленя о платежах для пользователей");
+    DISABLE_NOTIFICATION("/remove_reminder", "Выключить уведеомленя о платежах для пользователей"),
+    NOTIFY_REPORT_ON("/report_reminder_on", "Включить уведеомленя о пользователях, ненаписавших отчет"),
+    NOTIFY_REPORT_OFF("/report_reminder_off", "Выключить уведеомленя о платежах для пользователей");
 
     private String alias;
     private String description;

--- a/src/main/java/com/nekromant/telegram/model/NotificationReport.java
+++ b/src/main/java/com/nekromant/telegram/model/NotificationReport.java
@@ -1,0 +1,21 @@
+package com.nekromant.telegram.model;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.RequiredArgsConstructor;
+
+import javax.persistence.*;
+
+@Entity
+@Builder
+@RequiredArgsConstructor
+@AllArgsConstructor
+@Data
+public class NotificationReport {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    private boolean enable;
+}

--- a/src/main/java/com/nekromant/telegram/repository/NotificationReportRepository.java
+++ b/src/main/java/com/nekromant/telegram/repository/NotificationReportRepository.java
@@ -1,0 +1,13 @@
+package com.nekromant.telegram.repository;
+
+import com.nekromant.telegram.model.NotificationReport;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.CrudRepository;
+
+public interface NotificationReportRepository extends CrudRepository<NotificationReport, Long> {
+
+    @Query("SELECT f.enable FROM NotificationReport f")
+    Boolean getFlag();
+
+    NotificationReport getFirstByOrderByIdAsc();
+}

--- a/src/main/java/com/nekromant/telegram/service/NotificationReportService.java
+++ b/src/main/java/com/nekromant/telegram/service/NotificationReportService.java
@@ -1,0 +1,30 @@
+package com.nekromant.telegram.service;
+
+import com.nekromant.telegram.model.NotificationReport;
+import com.nekromant.telegram.repository.NotificationReportRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class NotificationReportService {
+
+    private final NotificationReportRepository notificationReportRepository;
+
+
+    public void enableReportNotification() {
+        NotificationReport notificationReport = notificationReportRepository.getFirstByOrderByIdAsc();
+        notificationReport.setEnable(true);
+        notificationReportRepository.save(notificationReport);
+    }
+
+    public void disableReportNotification() {
+        NotificationReport notificationReport = notificationReportRepository.getFirstByOrderByIdAsc();
+        notificationReport.setEnable(false);
+        notificationReportRepository.save(notificationReport);
+    }
+
+    public boolean isEnabled() {
+        return notificationReportRepository.getFlag();
+    }
+}

--- a/src/main/java/com/nekromant/telegram/sheduler/ReportReminderScheduler.java
+++ b/src/main/java/com/nekromant/telegram/sheduler/ReportReminderScheduler.java
@@ -4,6 +4,7 @@ import com.nekromant.telegram.contants.UserType;
 import com.nekromant.telegram.model.Report;
 import com.nekromant.telegram.model.UserInfo;
 import com.nekromant.telegram.repository.ReportRepository;
+import com.nekromant.telegram.service.NotificationReportService;
 import com.nekromant.telegram.service.SendMessageService;
 import com.nekromant.telegram.service.SpecialChatService;
 import com.nekromant.telegram.service.UserInfoService;
@@ -44,6 +45,8 @@ public class ReportReminderScheduler {
     private UserInfoService userInfoService;
     @Autowired
     private SendMessageService sendMessageService;
+    @Autowired
+    private NotificationReportService notificationReportService;
 
     @Scheduled(cron = "0 0 19 * * *")
     public void everyOneRemindAboutReports() {
@@ -73,7 +76,6 @@ public class ReportReminderScheduler {
 
     @Scheduled(cron = "0 0 8 * * *")
     public void reminderAboutStudentsWithoutReports() {
-
         Set<UserInfo> allStudents = reportRepository.findAll()
                 .stream()
                 .map(Report::getUserInfo)
@@ -111,7 +113,7 @@ public class ReportReminderScheduler {
 
 
         }
-        if (!badStudentsUsernames.isEmpty()) {
+        if (notificationReportService.isEnabled() && !badStudentsUsernames.isEmpty()) {
             sendMessageService.sendMessage(specialChatService.getMentorsChatId(),
                     String.format(MENTORS_REMINDER_STUDENT_WITHOUT_REPORTS, maxDaysWithoutReport) +
                             badStudentsUsernames.stream().map(studentName -> "@" + studentName).collect(Collectors.joining(",\n")));

--- a/src/main/resources/db/changelog/db.changelog-master.xml
+++ b/src/main/resources/db/changelog/db.changelog-master.xml
@@ -15,4 +15,5 @@
     <include file="/db/changelog/v1.0.0/009-db.changelog-addUtmTagsTable.xml"/>
     <include file="/db/changelog/v1.0.0/010-db.changelog-addColumnUtmTagInPaymentDetails.xml"/>
     <include file="/db/changelog/v1.0.0/011-db.changelog-addUserInfoColumnTimezone.xml"/>
+    <include file="/db/changelog/v1.0.0/013-db.changelog-new-Entity-NotificationReport.xml"/>
 </databaseChangeLog>

--- a/src/main/resources/db/changelog/v1.0.0/013-db.changelog-new-Entity-NotificationReport.xml
+++ b/src/main/resources/db/changelog/v1.0.0/013-db.changelog-new-Entity-NotificationReport.xml
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<databaseChangeLog xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+                   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                   xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
+                   https://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-latest.xsd">
+
+    <changeSet id="Notification-Report-entity" author="ninelive">
+
+        <createTable tableName="notification_report">
+            <column name="id" type="BIGINT" autoIncrement="true">
+                <constraints primaryKey="true" nullable="false"/>
+            </column>
+
+            <column name="enable" type="BOOLEAN">
+                <constraints nullable="false"/>
+            </column>
+        </createTable>
+
+        <insert tableName="notification_report">
+            <column name="id" valueNumeric="1"/>
+            <column name="enable" valueBoolean="false"/>
+        </insert>
+    </changeSet>
+</databaseChangeLog>


### PR DESCRIPTION
Добавил две команды для вкл/выкл уведомлений в чате менторов о пользователях, не написавших отчет n дней:
1) /report_reminder_off 
2) /report_reminder_on
Команда только для owner. Миграция создает модель, в которой хранит признак включенности уведомлений.