### PR TITLE
Добавлена команда /schedule

### DIFF
--- a/src/main/java/com/nekromant/telegram/commands/review/ScheduleReviewCommand.java
+++ b/src/main/java/com/nekromant/telegram/commands/review/ScheduleReviewCommand.java
@@ -1,0 +1,65 @@
+package com.nekromant.telegram.commands.review;
+
+import com.nekromant.telegram.commands.MentoringReviewCommand;
+import com.nekromant.telegram.model.UserInfo;
+import com.nekromant.telegram.service.ReviewScheduleService;
+import com.nekromant.telegram.service.UserInfoService;
+import com.nekromant.telegram.utils.SendMessageFactory;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Component;
+import org.telegram.telegrambots.meta.api.methods.send.SendMessage;
+import org.telegram.telegrambots.meta.api.objects.Chat;
+import org.telegram.telegrambots.meta.api.objects.User;
+import org.telegram.telegrambots.meta.bots.AbsSender;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
+import java.time.format.DateTimeParseException;
+
+import static com.nekromant.telegram.contants.Command.SCHEDULE_REVIEW;
+
+@Slf4j
+@Component
+public class ScheduleReviewCommand extends MentoringReviewCommand {
+    @Autowired
+    private SendMessageFactory sendMessageFactory;
+    @Autowired
+    private ReviewScheduleService reviewScheduleService;
+    @Autowired
+    private UserInfoService userInfoService;
+
+
+    public ScheduleReviewCommand() {
+        super(SCHEDULE_REVIEW.getAlias(), SCHEDULE_REVIEW.getDescription());
+    }
+
+    @Override
+    public void execute(AbsSender absSender, User user, Chat chat, String[] arguments) {
+        SendMessage message = sendMessageFactory.create(chat);
+        UserInfo userInfo = userInfoService.getUserInfo(user.getId());
+        if (arguments.length == 0) {
+            message.setText(reviewScheduleService.getSchedule(userInfo));
+        } else if (arguments.length == 2) {
+            try {
+                LocalDateTime[] dates = argumentsParser(arguments);
+                message.setText(reviewScheduleService.getSchedule(userInfo, dates[0], dates[1]));
+            } catch (DateTimeParseException e) {
+                message.setText("Неверный формат даты, попробуй:\n/schedule <dd.MM.yyyy> <dd.MM.yyyy>");
+            }
+        } else {
+            message.setText("Неверное количество аргументов, допустимые варианты:\n/schedule\n/schedule <dd.MM.yyyy> <dd.MM.yyyy>");
+        }
+        message.disableWebPagePreview();
+        execute(absSender, message, user);
+    }
+
+
+    private LocalDateTime[] argumentsParser(String[] arguments) {
+        DateTimeFormatter formatter = DateTimeFormatter.ofPattern("dd.MM.yyyy");
+        LocalDateTime t = LocalDate.parse(arguments[0], formatter).atStartOfDay();
+        LocalDateTime t2 = LocalDate.parse(arguments[1], formatter).atStartOfDay();
+        return new LocalDateTime[]{t, t2};
+    }
+}

--- a/src/main/java/com/nekromant/telegram/contants/Command.java
+++ b/src/main/java/com/nekromant/telegram/contants/Command.java
@@ -31,7 +31,8 @@ public enum Command {
     ENABLE_NOTIFICATION("/add_reminder", "Включить уведеомленя о платежах для пользователей"),
     DISABLE_NOTIFICATION("/remove_reminder", "Выключить уведеомленя о платежах для пользователей"),
     NOTIFY_REPORT_ON("/report_reminder_on", "Включить уведеомленя о пользователях, ненаписавших отчет"),
-    NOTIFY_REPORT_OFF("/report_reminder_off", "Выключить уведеомленя о платежах для пользователей");
+    NOTIFY_REPORT_OFF("/report_reminder_off", "Выключить уведеомленя о платежах для пользователей"),
+    SCHEDULE_REVIEW("/schedule", "Расписание всех ревью");
 
     private String alias;
     private String description;

--- a/src/main/java/com/nekromant/telegram/repository/ReviewRequestRepository.java
+++ b/src/main/java/com/nekromant/telegram/repository/ReviewRequestRepository.java
@@ -2,6 +2,7 @@ package com.nekromant.telegram.repository;
 
 import com.nekromant.telegram.model.ReviewRequest;
 import com.nekromant.telegram.model.UserInfo;
+import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.CrudRepository;
 
 import java.time.LocalDateTime;
@@ -11,7 +12,11 @@ public interface ReviewRequestRepository extends CrudRepository<ReviewRequest, L
     void deleteAllByBookedDateTimeIsBefore(LocalDateTime dateTime);
 
     List<ReviewRequest> findAllByBookedDateTimeBetween(LocalDateTime from, LocalDateTime to);
-
+    @Query(value = "SELECT * FROM review_request " +
+            "WHERE booked_date_time IS NOT NULL " +
+            "ORDER BY booked_date_time DESC " +
+            "LIMIT 1", nativeQuery = true)
+    ReviewRequest findFirstByOrderByBookedDateTimeDesc();
     List<ReviewRequest> findAll();
 
     boolean existsByBookedDateTimeAndMentorInfo(LocalDateTime dateTime, UserInfo userInfo);

--- a/src/main/java/com/nekromant/telegram/service/ReviewScheduleService.java
+++ b/src/main/java/com/nekromant/telegram/service/ReviewScheduleService.java
@@ -62,17 +62,18 @@ public class ReviewScheduleService {
 
         for (LocalDate date : allDates) {
             result.append(date.format(defaultDateFormatter()) + "\n");
-            reviewRequests.stream()
+            result.append(reviewRequests.stream()
                     .filter(reviewRequest -> reviewRequest.getBookedDateTime().toLocalDate().equals(date))
-                    .forEach(review -> result.append("\n" +
+                    .map(review ->
                             "@" + review.getStudentInfo().getUserName() + "\n" +
-                            timezoneService.convertToUserZone(review.getBookedDateTime(), userInfo).format(defaultTimeFormatter()) + "\n" +
-                            review.getTitle() + "\n" +
-                            "@" + review.getMentorInfo().getUserName() + "\n" +
-                            mentorRepository.findMentorByMentorInfo(review.getMentorInfo()).getRoomUrl() + "\n"));
+                                    "\u23F1" + review.getBookedDateTime().format(defaultTimeFormatter()) + "\n" +
+                                    review.getTitle() + "\n" +
+                                    "@" + review.getMentorInfo().getUserName() + "\n" +
+                                    mentorRepository.findMentorByMentorInfo(review.getMentorInfo()).getRoomUrl())
+                    .collect(Collectors.joining("\n\n")));
 
             if (!date.equals(allDates.get(allDates.size() - 1))) {
-                result.append("<----------------------->\n");
+                result.append("\n<----------------------->\n");
             }
         }
         return result.toString();

--- a/src/main/java/com/nekromant/telegram/service/ReviewScheduleService.java
+++ b/src/main/java/com/nekromant/telegram/service/ReviewScheduleService.java
@@ -24,8 +24,6 @@ public class ReviewScheduleService {
     private MentorRepository mentorRepository;
     @Autowired
     private ReviewRequestRepository reviewRequestRepository;
-    @Autowired
-    private TimezoneService timezoneService;
 
     public String getSchedule(UserInfo user) {
         LocalDateTime todayDate = LocalDate.now(ZoneId.of("Europe/Moscow")).atStartOfDay();
@@ -38,7 +36,11 @@ public class ReviewScheduleService {
     }
 
     public String getSchedule(UserInfo user, LocalDateTime fromDate, LocalDateTime toDate) {
-        return formatHeader(fromDate, toDate) + scheduleContentFormatter(user, fromDate, toDate);
+        if (fromDate.isBefore(toDate)){
+            return formatHeader(fromDate, toDate) + scheduleContentFormatter(user, fromDate, toDate);
+        } else {
+            return formatHeader(fromDate, fromDate) + scheduleContentFormatter(user, fromDate, fromDate);
+        }
     }
 
     public String getScheduleToday(UserInfo user) {
@@ -46,6 +48,7 @@ public class ReviewScheduleService {
                 LocalDate.now(ZoneId.of("Europe/Moscow")).atStartOfDay());
     }
 
+    // Если нужно будет добавить таймзоны пользователей, то оставлен userInfo
     private String scheduleContentFormatter(UserInfo userInfo, LocalDateTime fromDate, LocalDateTime toDate) {
         List<ReviewRequest> reviewRequests = reviewRequestRepository.findAllByBookedDateTimeBetween(
                 fromDate.toLocalDate().atStartOfDay(), toDate.toLocalDate().plusDays(1).atStartOfDay());

--- a/src/main/java/com/nekromant/telegram/service/ReviewScheduleService.java
+++ b/src/main/java/com/nekromant/telegram/service/ReviewScheduleService.java
@@ -1,0 +1,85 @@
+package com.nekromant.telegram.service;
+
+
+import com.nekromant.telegram.model.ReviewRequest;
+import com.nekromant.telegram.model.UserInfo;
+import com.nekromant.telegram.repository.MentorRepository;
+import com.nekromant.telegram.repository.ReviewRequestRepository;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.ZoneId;
+import java.util.Comparator;
+import java.util.List;
+import java.util.stream.Collectors;
+
+import static com.nekromant.telegram.contants.MessageContants.NO_REVIEW_TODAY;
+import static com.nekromant.telegram.utils.FormatterUtils.*;
+
+@Service
+public class ReviewScheduleService {
+    @Autowired
+    private MentorRepository mentorRepository;
+    @Autowired
+    private ReviewRequestRepository reviewRequestRepository;
+    @Autowired
+    private TimezoneService timezoneService;
+
+    public String getSchedule(UserInfo user) {
+        LocalDateTime todayDate = LocalDate.now(ZoneId.of("Europe/Moscow")).atStartOfDay();
+        LocalDateTime dateLastReview = reviewRequestRepository.findFirstByOrderByBookedDateTimeDesc().getBookedDateTime();
+        if (todayDate.isBefore(dateLastReview)) {
+            return formatHeader(todayDate, dateLastReview) + scheduleContentFormatter(user, todayDate, dateLastReview);
+        } else {
+            return formatHeader(todayDate, todayDate) + scheduleContentFormatter(user, todayDate, todayDate);
+        }
+    }
+
+    public String getSchedule(UserInfo user, LocalDateTime fromDate, LocalDateTime toDate) {
+        return formatHeader(fromDate, toDate) + scheduleContentFormatter(user, fromDate, toDate);
+    }
+
+    public String getScheduleToday(UserInfo user) {
+        return "Расписание ревью на сегодня:\n" + scheduleContentFormatter(user, LocalDate.now(ZoneId.of("Europe/Moscow")).atStartOfDay(),
+                LocalDate.now(ZoneId.of("Europe/Moscow")).atStartOfDay());
+    }
+
+    private String scheduleContentFormatter(UserInfo userInfo, LocalDateTime fromDate, LocalDateTime toDate) {
+        List<ReviewRequest> reviewRequests = reviewRequestRepository.findAllByBookedDateTimeBetween(
+                fromDate.toLocalDate().atStartOfDay(), toDate.toLocalDate().plusDays(1).atStartOfDay());
+        if (reviewRequests.isEmpty()) {
+            return NO_REVIEW_TODAY;
+        }
+        StringBuilder result = new StringBuilder();
+        reviewRequests.sort(Comparator.comparing(ReviewRequest::getBookedDateTime));
+        List<LocalDate> allDates = reviewRequests.stream()
+                .map(ReviewRequest::getBookedDateTime)
+                .map(LocalDateTime::toLocalDate)
+                .distinct()
+                .collect(Collectors.toList());
+
+        for (LocalDate date : allDates) {
+            result.append(date.format(defaultDateFormatter()) + "\n");
+            reviewRequests.stream()
+                    .filter(reviewRequest -> reviewRequest.getBookedDateTime().toLocalDate().equals(date))
+                    .forEach(review -> result.append("\n" +
+                            "@" + review.getStudentInfo().getUserName() + "\n" +
+                            timezoneService.convertToUserZone(review.getBookedDateTime(), userInfo).format(defaultTimeFormatter()) + "\n" +
+                            review.getTitle() + "\n" +
+                            "@" + review.getMentorInfo().getUserName() + "\n" +
+                            mentorRepository.findMentorByMentorInfo(review.getMentorInfo()).getRoomUrl() + "\n"));
+
+            if (!date.equals(allDates.get(allDates.size() - 1))) {
+                result.append("<----------------------->\n");
+            }
+        }
+        return result.toString();
+    }
+
+    private String formatHeader(LocalDateTime fromDate, LocalDateTime toDate) {
+        return "Расписание всех ревью с " + fromDate.toLocalDate().format(defaultDateFormatter()) + " по "
+                + toDate.toLocalDate().format(defaultDateFormatter()) + ":\n";
+    }
+}

--- a/src/main/java/com/nekromant/telegram/utils/FormatterUtils.java
+++ b/src/main/java/com/nekromant/telegram/utils/FormatterUtils.java
@@ -11,4 +11,7 @@ public class FormatterUtils {
     public static DateTimeFormatter defaultDateTimeFormatter() {
         return DateTimeFormatter.ofPattern("dd.MM.yyyy HH:mm");
     }
+    public static DateTimeFormatter defaultTimeFormatter(){
+        return DateTimeFormatter.ofPattern("HH:mm");
+    }
 }

--- a/src/test/java/com/nekromant/telegram/service/ReviewScheduleServiceTest.java
+++ b/src/test/java/com/nekromant/telegram/service/ReviewScheduleServiceTest.java
@@ -33,7 +33,7 @@ public class ReviewScheduleServiceTest {
 
     @Test
     void getSchedule_OneDay_returnCorrectSchedule() {
-        //Arrange
+
         LocalDateTime date = LocalDateTime.of(2025, 12, 12, 12, 12);
         String formattedDate = date.format(defaultDateFormatter());
         ReviewRequest reviewRequest = createMockReviewRequest(date);
@@ -42,9 +42,9 @@ public class ReviewScheduleServiceTest {
         when(mentorRepository.findMentorByMentorInfo(any())).thenReturn(mentor);
         when(reviewRequestRepository.findAllByBookedDateTimeBetween(any(), any()))
                 .thenReturn(new ArrayList<>(List.of(reviewRequest)));
-        //Act
+
         String result = reviewScheduleService.getSchedule(new UserInfo(), date, date);
-        //Assert
+
         assertThat(result).contains(String.format("Расписание всех ревью с %s по %s:\n", formattedDate, formattedDate));
         assertThat(result).contains("@test_user");
         assertThat(result).contains("@test_mentor");
@@ -54,21 +54,21 @@ public class ReviewScheduleServiceTest {
 
     @Test
     void getSchedule_NoReview_returnNoReviewSchedule() {
-        //Arrange
+
         LocalDateTime date = LocalDateTime.of(2025, 12, 12, 12, 12);
         String formattedDate = date.format(defaultDateFormatter());
         when(reviewRequestRepository.findAllByBookedDateTimeBetween(any(), any()))
-                .thenReturn(new ArrayList<>()); // empty reviewlist
-        //Act
+                .thenReturn(new ArrayList<>());
+
         String result = reviewScheduleService.getSchedule(new UserInfo(), date, date);
-        //Assert
+
         assertThat(result).contains(String.format("Расписание всех ревью с %s по %s:\n", formattedDate, formattedDate));
         assertThat(result).contains(NO_REVIEW_TODAY);
     }
 
     @Test
     void getSchedule_ToDateBeforeFromDate_returnTodaySchedule(){
-        //Arrange
+
         LocalDateTime fromDate = LocalDateTime.of(2025, 12, 12, 12, 12);
         LocalDateTime toDate = LocalDateTime.of(2024, 11, 11, 11, 11);
         String formattedDate = fromDate.format(defaultDateFormatter());
@@ -78,9 +78,9 @@ public class ReviewScheduleServiceTest {
         when(mentorRepository.findMentorByMentorInfo(any())).thenReturn(mentor);
         when(reviewRequestRepository.findAllByBookedDateTimeBetween(any(), any()))
                 .thenReturn(new ArrayList<>(List.of(reviewRequest)));
-        //Act
+
         String result = reviewScheduleService.getSchedule(new UserInfo(), fromDate, toDate);
-        //Assert
+
         assertThat(result).contains(String.format("Расписание всех ревью с %s по %s:\n", formattedDate, formattedDate));
         assertThat(result).contains("@test_user");
         assertThat(result).contains("@test_mentor");
@@ -88,7 +88,7 @@ public class ReviewScheduleServiceTest {
     }
     @Test
     void getScheduleToday_AnyDates_returnTodaySchedule() {
-        //Arrange
+
         LocalDateTime fromDate = LocalDateTime.of(2025, 12, 12, 12, 12);
         ReviewRequest reviewRequest = createMockReviewRequest(fromDate);
         Mentor mentor = new Mentor();
@@ -97,10 +97,10 @@ public class ReviewScheduleServiceTest {
         when(reviewRequestRepository.findAllByBookedDateTimeBetween(any(), any()))
                 .thenReturn(new ArrayList<>(List.of(reviewRequest)));
 
-        //Act
+
         String result = reviewScheduleService.getScheduleToday(new UserInfo());
 
-        //Assert
+
         assertThat(result).contains("Расписание ревью на сегодня:");
         assertThat(result).contains("@test_user");
         assertThat(result).contains("@test_mentor");

--- a/src/test/java/com/nekromant/telegram/service/ReviewScheduleServiceTest.java
+++ b/src/test/java/com/nekromant/telegram/service/ReviewScheduleServiceTest.java
@@ -1,0 +1,95 @@
+package com.nekromant.telegram.service;
+
+import com.nekromant.telegram.model.Mentor;
+import com.nekromant.telegram.model.ReviewRequest;
+import com.nekromant.telegram.model.UserInfo;
+import com.nekromant.telegram.repository.MentorRepository;
+import com.nekromant.telegram.repository.ReviewRequestRepository;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.stream.Stream;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+public class ReviewScheduleServiceTest {
+    @InjectMocks
+    private ReviewScheduleService reviewScheduleService;
+    @Mock
+    private ReviewRequestRepository reviewRequestRepository;
+    @Mock
+    private UserInfoService userInfoService;
+    @Mock
+    private MentorRepository mentorRepository;
+
+    @ParameterizedTest
+    @MethodSource("provideDateListArguments")
+    void getSchedule_AnyDates_returnCorrectSchedule(LocalDateTime fromDate, LocalDateTime toDate) {
+        //Arrange
+        ReviewRequest reviewRequest = createMockReviewRequest(fromDate);
+        Mentor mentor = new Mentor();
+        mentor.setRoomUrl("test_url");
+        when(mentorRepository.findMentorByMentorInfo(any())).thenReturn(mentor);
+        when(reviewRequestRepository.findAllByBookedDateTimeBetween(any(), any()))
+                .thenReturn(new ArrayList<>(List.of(reviewRequest)));
+        //Act
+        //Assert
+        Assertions.assertDoesNotThrow(() -> reviewScheduleService.getSchedule(new UserInfo(), fromDate, toDate));
+    }
+
+    @Test
+    void getScheduleToday_AnyDates_returnTodaySchedule() {
+        //Arrange
+        LocalDateTime fromDate = LocalDateTime.of(2025, 12, 12, 12, 12);
+        ReviewRequest reviewRequest = createMockReviewRequest(fromDate);
+        Mentor mentor = new Mentor();
+        mentor.setRoomUrl("test_url");
+        when(mentorRepository.findMentorByMentorInfo(any())).thenReturn(mentor);
+        when(reviewRequestRepository.findAllByBookedDateTimeBetween(any(), any()))
+                .thenReturn(new ArrayList<>(List.of(reviewRequest)));
+
+        //Act
+        String result = reviewScheduleService.getScheduleToday(new UserInfo());
+
+        //Assert
+        assertThat(result).contains("Расписание ревью на сегодня:");
+        assertThat(result).contains("@test_user");
+        assertThat(result).contains("@test_mentor");
+        assertThat(result).contains("12:12");
+    }
+
+
+    private static Stream<Arguments> provideDateListArguments() {
+        return Stream.of(
+                Arguments.of(LocalDateTime.of(2025, 12, 12, 12, 12), LocalDateTime.of(2026, 11, 11, 11, 11)),
+                Arguments.of(LocalDateTime.of(2025, 12, 12, 12, 12), LocalDateTime.of(2025, 12, 12, 12, 12)),
+                Arguments.of(LocalDateTime.of(2026, 11, 11, 11, 11), LocalDateTime.of(2025, 12, 12, 12, 12))
+        );
+    }
+
+    private ReviewRequest createMockReviewRequest(LocalDateTime date) {
+        UserInfo user = new UserInfo();
+        user.setUserName("test_user");
+        UserInfo mentorInfo = new UserInfo();
+        mentorInfo.setUserName("test_mentor");
+        ReviewRequest reviewRequest = new ReviewRequest();
+        reviewRequest.setBookedDateTime(date);
+        reviewRequest.setTitle("test_title");
+        reviewRequest.setStudentInfo(user);
+        reviewRequest.setMentorInfo(mentorInfo);
+        return reviewRequest;
+    }
+}


### PR DESCRIPTION
Добавлена команда /schedule, отображающая расписание всех забронированных ревью. 
/schedule - выводит все ревью от сегодняшнего дня до последнего существующего ревью
/schedule <dd.MM.yyyy> <dd.MM.yyyy> - выводит ревью за период
Рефакторинг /review_today, создание текста с расписанием вынесено в сервис ReviewScheduleService